### PR TITLE
Eval: Elo ladder + mixed-opponent datagen (distillation has saturated)

### DIFF
--- a/rl/TRAINING_HISTORY.md
+++ b/rl/TRAINING_HISTORY.md
@@ -733,3 +733,60 @@ the improvement operator honest against a population instead of one partner.
 | Player | vs 3×FF | vs 3×Chicken |
 |--------|---------|--------------|
 | **`best_raw_net.pt` = `exit_sp1b_soft/exit_final.pt`** | **+$2.13 / 21.0%** | **+$10.10 / 24.8%** |
+
+### Mixed-opponent ExIt round — BREAKS THE PLATEAU (2026-07-09)  ⭐
+Hypothesis (from round-2 specialization): the loop plateaued because datagen
+seats 1-3 were all copies of the champion, so distillation learned to beat one
+partner, not to improve in general. Fix (exit_datagen3.py): seat 0 = champion
+(sp1b) + NN-guided search, but each game's opponents drawn from a POPULATION —
+55% mixed self-play (seats 1-3 each sampled from {sp1b, r3, r2, imitation}),
+30% FirstFelix tables, 15% Chicken tables.
+
+12k games (6 workers) then, after an OOM pause, resumed leaner (3 workers,
+fresh seeds) — ~8,700 combined games, 87 shards (exit_mix1 + exit_mix1_r2).
+Distilled `exit_mix_soft/exit_final.pt` (warm-start sp1b, soft-Q, 6 epochs).
+
+**Gates vs sp1b — ALL THREE POSITIVE (universal gain, unlike round 2):**
+| Gate | delta (D − sp1b) |
+|------|------------------|
+| head-to-head league (2000×2) | **+$2.01 ± 0.81** (~2.5σ) |
+| vs 3×FF (3000) | +$0.68 ± 0.65 (win 20.9→23.2%) |
+| vs 3×Chicken (3000) | +$0.52 ± 0.52 (win 24.7→26.5%) |
+
+Contrast round 2 (same-partner): league +1.28 but FF +0.24 / Chicken −0.64.
+Opponent diversity converted a specializing loop back into a generalizing one.
+**PROMOTED as new champion** → `rl/checkpoints/best_raw_net.pt`.
+
+NEW BEST (2026-07-09):
+| Player | vs 3×FF | vs 3×Chicken |
+|--------|---------|--------------|
+| **`exit_mix_soft/exit_final.pt` (= best_raw_net.pt)** | **+$3.38 / 23.2%** | **+$10.62 / 26.5%** |
+
+Next: another mixed-opponent round with the new champion added to the pool
+(keep diversifying), or pivot to deeper search (issue #13 belief-state
+determinization). Add an Elo ladder now that head-to-head is the live metric.
+
+**CAVEAT (transitivity check, same day):** D vs r3 head-to-head = −$0.29 ± 0.90
+(EVEN), despite sp1b>r3 (+1.13) and D>sp1b (+2.01). Intransitive — head-to-head
+is matchup-dependent here (D's pool/search centered on sp1b, giving an
+anti-sp1b edge). D's promotion stands on the FIXED anchors (FF +0.68, Chicken
++0.52, both positive) but the gain is MODEST, not the +2.01 league number.
+Two head-to-head misleads now (round-2 false positive, this r3 anomaly) →
+build an ELO LADDER (round-robin over {r3,sp1b,D,imitation}+FF+Chicken) BEFORE
+the next round; stop trusting single pairwise duels for the promote decision.
+
+### Elo ladder (#15) — post-r3 nets are a TIE and an intransitive cycle (2026-07-09)
+Built rl/elo_ladder.py: paired round-robin, money-scale least-squares rating,
+bootstrap CIs, explicit intransitivity residual. Over {r3, sp1b, D, imit},
+2000 games/pair:
+- Ratings: D +0.52 / r3 +0.08 / sp1b -0.20 / imit -0.39 — ALL CIs overlap (no
+  net separated at 95%).
+- **Intransitivity $0.65/game** (≈ the whole rating spread): cycle
+  sp1b>r3 (+0.53), D>sp1b (+1.68), r3>D (+0.56).
+- Anchor calibration (common seeds): vs FF r3 best / D worst; vs Chicken D best
+  / sp1b worst — all within ~$0.5.
+**Conclusion:** the r3→sp1b→D "climb" was pairwise-gate noise; on fixed
+benchmarks and by ladder rating the three are peers. Distillation-of-search has
+saturated. The ladder (rl/checkpoints/elo.md) is now the promotion gate. Next
+real lever = stronger teacher (belief-state determinization + IS-MCTS, #13),
+not more distill rounds.

--- a/rl/elo_ladder.py
+++ b/rl/elo_ladder.py
@@ -1,0 +1,207 @@
+"""
+elo_ladder.py — trustworthy strength ranking over a pool of net checkpoints.
+
+Head-to-head "money" duels are matchup-dependent (intransitive) in a 4-player
+imperfect-info game, so single pairwise numbers have misled promotion twice.
+This fits ONE consistent 1-D rating from the full paired round-robin.
+
+Method
+──────
+For every unordered pair (X, Y) of nets, on the SAME seeds, play both
+  config A: seat0 = X, seats1-3 = Y   -> money_X = X's reward as lone-vs-3Y
+  config B: seat0 = Y, seats1-3 = X   -> money_Y = Y's reward as lone-vs-3X
+The paired advantage a_XY = mean(money_X - money_Y) is antisymmetric and, in a
+transitive world, equals r_X - r_Y. We fit ratings r (in $/game units, mean 0)
+by weighted least squares on all a_XY (a weighted graph-Laplacian solve):
+minimise  sum_{i<j} w_ij ( a_ij - (r_i - r_j) )^2 ,  w_ij = 1/SE_ij^2.
+
+The weighted RMS residual of a_ij - (r_i - r_j) is the INTRANSITIVITY: how much
+the pairwise results deviate from any single ranking. Bootstrap over seeds gives
+per-rating CIs.
+
+Ratings are on a money scale: r_X - r_Y ~ expected $/game X makes exploiting a
+table of Y minus the reverse. FF/Chicken anchors are reported as a separate
+calibration (each net's $/game as lone-vs-3anchor) — folding heuristics in as
+full players needs a heuristic-seat-0 env (follow-up).
+
+Usage
+─────
+    rl/venv/bin/python rl/elo_ladder.py \
+        --players r3=rl/checkpoints/exit_v3_r3_soft/exit_final.pt \
+                  sp1b=rl/checkpoints/exit_sp1b_soft/exit_final.pt \
+                  D=rl/checkpoints/exit_mix_soft/exit_final.pt \
+                  imit=rl/checkpoints/imitation_v3d/imitation_epoch10.pt \
+        --n-games 1000 --n-workers 3 --out rl/checkpoints/elo.md
+"""
+
+import argparse
+import itertools
+import sys
+import time
+from concurrent.futures import ProcessPoolExecutor
+from pathlib import Path
+
+import numpy as np
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+_W = {}
+
+
+def _worker_init(jar, players):
+    import torch
+    torch.set_num_threads(1)
+    from model import MahjongAgent
+    from self_play import TrueSelfPlayEnv
+    _W["agents"] = {name: MahjongAgent.load(path, device="cpu")
+                    for name, path in players}
+    _W["env"] = TrueSelfPlayEnv(jar)
+
+
+def _lone_money(seat_assign, seed):
+    """Play one game with the given seat->player assignment; return seat-0 money."""
+    from env import encode_state, get_action_mask
+    env = _W["env"]
+    msg = env.reset(seed=seed)
+    while True:
+        if msg["type"] == "game_over":
+            return float(msg["rewards"]["0"])
+        seat = int(msg["seat_id"])
+        agent = _W["agents"][seat_assign[seat]]
+        obs = encode_state(msg["state"], version=3, context=msg.get("context"))
+        mask = get_action_mask(msg["decision"], msg.get("context", {}))
+        action = agent.select_action(obs, msg["decision"], mask, deterministic=True)
+        msg = env.step(msg["decision"], int(action))
+
+
+def _play_pair(task):
+    """task = (X, Y, seed) -> (X, Y, seed, moneyX_lone_vs_3Y, moneyY_lone_vs_3X)"""
+    X, Y, seed = task
+    mX = _lone_money({0: X, 1: Y, 2: Y, 3: Y}, seed)
+    mY = _lone_money({0: Y, 1: X, 2: X, 3: X}, seed)
+    return (X, Y, seed, mX, mY)
+
+
+def fit_ratings(names, adv, weight):
+    """Weighted least-squares ratings (mean 0) from antisymmetric advantage adv[i][j]."""
+    n = len(names)
+    L = np.zeros((n, n))
+    b = np.zeros(n)
+    for i in range(n):
+        for j in range(n):
+            if i == j:
+                continue
+            w = weight[i][j]
+            L[i, i] += w
+            L[i, j] -= w
+            b[i] += w * adv[i][j]
+    # enforce mean-zero: solve (L + 1/n * J) r = b  (regularises the null space)
+    L += np.ones((n, n)) / n
+    r = np.linalg.solve(L, b)
+    r -= r.mean()
+    return r
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--jar", default="target/scala-2.12/mahjong-assembly-0.1.0.jar")
+    p.add_argument("--players", nargs="+", required=True,
+                   help="name=path entries")
+    p.add_argument("--n-games", type=int, default=1000, help="paired games per pair")
+    p.add_argument("--n-workers", type=int, default=3)
+    p.add_argument("--seed-offset", type=int, default=50_000_000)
+    p.add_argument("--boot", type=int, default=500, help="bootstrap resamples")
+    p.add_argument("--out", default="rl/checkpoints/elo.md")
+    args = p.parse_args()
+
+    players = [tuple(kv.split("=", 1)) for kv in args.players]
+    names = [n for n, _ in players]
+    idx = {n: i for i, n in enumerate(names)}
+    pairs = list(itertools.combinations(names, 2))
+    seeds = list(range(args.seed_offset, args.seed_offset + args.n_games))
+
+    tasks = [(X, Y, s) for (X, Y) in pairs for s in seeds]
+    print(f"Ladder over {len(names)} nets, {len(pairs)} pairs x {args.n_games} "
+          f"paired games = {len(tasks)*2} self-play games")
+    sys.stdout.flush()
+
+    # collect per-seed advantage samples per pair
+    diffs = {pair: [] for pair in pairs}
+    t0 = time.time()
+    done = 0
+    with ProcessPoolExecutor(max_workers=args.n_workers,
+                             initializer=_worker_init,
+                             initargs=(args.jar, players)) as pool:
+        for (X, Y, seed, mX, mY) in pool.map(_play_pair, tasks, chunksize=8):
+            diffs[(X, Y)].append(mX - mY)
+            done += 1
+            if done % 2000 == 0:
+                print(f"  [{done}/{len(tasks)}] {time.time()-t0:.0f}s")
+                sys.stdout.flush()
+
+    n = len(names)
+    adv = np.zeros((n, n)); se = np.ones((n, n)); weight = np.zeros((n, n))
+    samples = {}
+    for (X, Y), d in diffs.items():
+        d = np.array(d); i, j = idx[X], idx[Y]
+        a = d.mean(); s = d.std(ddof=1) / np.sqrt(len(d)) + 1e-9
+        adv[i][j] = a;  adv[j][i] = -a
+        se[i][j] = s;   se[j][i] = s
+        weight[i][j] = weight[j][i] = 1.0 / s**2
+        samples[(X, Y)] = d
+
+    r = fit_ratings(names, adv, weight)
+
+    # bootstrap CIs + intransitivity
+    boot = np.zeros((args.boot, n))
+    for b in range(args.boot):
+        adv_b = np.zeros((n, n))
+        for (X, Y), d in samples.items():
+            i, j = idx[X], idx[Y]
+            bs = np.random.choice(d, size=len(d), replace=True).mean()
+            adv_b[i][j] = bs; adv_b[j][i] = -bs
+        boot[b] = fit_ratings(names, adv_b, weight)
+    lo = np.percentile(boot, 2.5, axis=0)
+    hi = np.percentile(boot, 97.5, axis=0)
+
+    # intransitivity: weighted RMS residual of adv - (r_i - r_j)
+    num = den = 0.0
+    for i in range(n):
+        for j in range(i + 1, n):
+            resid = adv[i][j] - (r[i] - r[j])
+            num += weight[i][j] * resid**2
+            den += weight[i][j]
+    intransitivity = np.sqrt(num / den)
+
+    order = np.argsort(-r)
+    lines = []
+    lines.append("# Strength ladder (money-scale rating, $/game, mean 0)\n")
+    lines.append(f"Paired round-robin, {args.n_games} games/pair. "
+                 f"Rating diff ~ expected $/game one net exploits a table of the "
+                 f"other, minus the reverse.\n")
+    lines.append(f"**Intransitivity (weighted RMS residual): "
+                 f"${intransitivity:.2f}/game** — how far pairwise results "
+                 f"deviate from a single ranking (0 = perfectly transitive).\n")
+    lines.append("| rank | net | rating | 95% CI |")
+    lines.append("|------|-----|--------|--------|")
+    for rank, i in enumerate(order, 1):
+        lines.append(f"| {rank} | {names[i]} | {r[i]:+.2f} | "
+                     f"[{lo[i]:+.2f}, {hi[i]:+.2f}] |")
+    lines.append("\n## Pairwise advantage matrix (row = lone, col = table of; "
+                 "$/game, row−col direction)\n")
+    lines.append("| |" + "|".join(names) + "|")
+    lines.append("|" + "---|" * (n + 1))
+    for i in range(n):
+        row = [f"**{names[i]}**"]
+        for j in range(n):
+            row.append("—" if i == j else f"{adv[i][j]:+.2f}±{se[i][j]:.2f}")
+        lines.append("|" + "|".join(row) + "|")
+    out = "\n".join(lines) + "\n"
+
+    print("\n" + out)
+    Path(args.out).write_text(out)
+    print(f"written -> {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/rl/exit_datagen3.py
+++ b/rl/exit_datagen3.py
@@ -1,0 +1,221 @@
+"""
+exit_datagen3.py — Expert Iteration datagen with a POPULATION of opponents.
+
+Round 2 (exit_datagen2) plateaued from self-play specialization: seats 1-3
+were all copies of the champion, so the distilled net learned to beat *that
+one partner* rather than getting stronger in general. This variant fixes the
+exact failure: seat 0 stays champion + NN-guided search (the teacher), but the
+opponents each game are drawn from a diverse pool so the improvement operator
+stays honest against a population.
+
+Per game, one of three table types is chosen (weighted, deterministic by seed):
+  mixed   : self-play env, seats 1-3 each independently sampled from a pool of
+            net checkpoints (champion, r3, r2, imitation base)
+  ff      : seat 0 vs 3 FirstFelix
+  chicken : seat 0 vs 3 Chicken
+
+Only seat 0's (search-improved) decisions are recorded. Shard format is
+identical to exit_datagen2, so exit_distill_soft.py consumes it unchanged.
+
+Launch N workers with disjoint strided seeds:
+
+    for w in $(seq 0 5); do
+      nohup rl/venv/bin/python rl/exit_datagen3.py --worker-id $w --n-workers 6 \
+        --n-games 12000 --champion rl/checkpoints/exit_sp1b_soft/exit_final.pt \
+        --nn-model rl/checkpoints/student/student48_sp1b.onnx \
+        --save-dir rl/data/exit_mix1 > rl/data/exit_mix1/worker$w.log 2>&1 &
+    done
+"""
+
+import argparse
+import sys
+import time
+from collections import defaultdict
+from pathlib import Path
+
+import numpy as np
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+DEFAULT_POOL = [
+    "rl/checkpoints/exit_sp1b_soft/exit_final.pt",
+    "rl/checkpoints/exit_v3_r3_soft/exit_final.pt",
+    "rl/checkpoints/exit_v3_r2_soft/exit_final.pt",
+    "rl/checkpoints/imitation_v3d/imitation_epoch10.pt",
+]
+# table-type mix (weights need not sum to 1; normalised below)
+MIX = [("mixed", 0.55), ("ff", 0.30), ("chicken", 0.15)]
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--jar", default="target/scala-2.12/mahjong-assembly-0.1.0.jar")
+    p.add_argument("--champion", required=True,
+                   help="seat-0 net (also the distillation warm-start base)")
+    p.add_argument("--pool", nargs="+", default=DEFAULT_POOL,
+                   help="net checkpoints for opponent seats in 'mixed' tables")
+    p.add_argument("--nn-model", required=True,
+                   help="ONNX student for NN rollout policy")
+    p.add_argument("--rollout-threads", type=int, default=3)
+    p.add_argument("--worker-id", type=int, default=0)
+    p.add_argument("--n-workers", type=int, default=1)
+    p.add_argument("--n-games", type=int, default=12_000,
+                   help="TOTAL games across all workers")
+    p.add_argument("--seed-offset", type=int, default=30_000_000)
+    p.add_argument("--n-worlds", type=int, default=64)
+    p.add_argument("--top-k", type=int, default=6)
+    p.add_argument("--z-threshold", type=float, default=1.5)
+    p.add_argument("--min-gain", type=float, default=0.25)
+    p.add_argument("--games-per-shard", type=int, default=100)
+    p.add_argument("--save-dir", required=True)
+    args = p.parse_args()
+
+    import torch
+    torch.set_num_threads(1)
+    from env import MahjongEnv, encode_state, get_action_mask
+    from model import MahjongAgent
+    from mcts import MCTSRolloutClient, PairedMCTSPolicy
+    from self_play import TrueSelfPlayEnv
+
+    save_dir = Path(args.save_dir)
+    save_dir.mkdir(parents=True, exist_ok=True)
+
+    champ = MahjongAgent.load(args.champion, device="cpu")
+    assert champ.net.obs_dim == 759, "expects a v3 net"
+    pool = [MahjongAgent.load(c, device="cpu") for c in args.pool]
+
+    client = MCTSRolloutClient(
+        jar_path=args.jar, rollout_opp="firstfelix",
+        nn_model=args.nn_model, rollout_threads=args.rollout_threads)
+    policy = PairedMCTSPolicy(
+        net=champ.net, rollout_client=client,
+        n_worlds=args.n_worlds, top_k=args.top_k,
+        z_threshold=args.z_threshold, min_gain=args.min_gain,
+        device="cpu", self_policy="nn")
+
+    sp_env = TrueSelfPlayEnv(args.jar)
+    ff_env = MahjongEnv(args.jar, opponent="firstfelix", obs_version=3)
+    ch_env = MahjongEnv(args.jar, opponent="chicken", obs_version=3)
+
+    # deterministic table-type + opponent assignment by seed (stride-safe)
+    types, weights = zip(*MIX)
+    cum = np.cumsum(np.array(weights) / sum(weights))
+
+    def table_for(seed):
+        r = ((seed * 2654435761) % 10_000) / 10_000.0
+        return types[int(np.searchsorted(cum, r))]
+
+    def pool_seat(seed, seat):
+        return pool[(seed * 7 + seat * 101) % len(pool)]
+
+    my_seeds = [args.seed_offset + g for g in range(args.n_games)
+                if g % args.n_workers == args.worker_id]
+    print(f"[worker {args.worker_id}] {len(my_seeds)} games | pool={len(pool)} "
+          f"nets | mix={dict(MIX)} | rollout self=nn opp=ff")
+    sys.stdout.flush()
+
+    buf = defaultdict(list)
+    game_rewards = []
+    type_counts = defaultdict(int)
+    shard_idx = 0
+    t0 = time.time()
+    K = args.top_k
+
+    def flush():
+        nonlocal shard_idx, buf
+        if not any(buf.values()):
+            return
+        out = {}
+        for dec, samples in buf.items():
+            out[f"{dec}_obs"] = np.array([s["obs"] for s in samples], dtype=np.float32)
+            out[f"{dec}_act"] = np.array([s["act"] for s in samples], dtype=np.int64)
+            out[f"{dec}_mask"] = np.array([s["mask"] for s in samples], dtype=bool)
+            out[f"{dec}_switched"] = np.array([s["switched"] for s in samples], dtype=bool)
+            if dec == "discard":
+                out["discard_cands"] = np.array([s["cands"] for s in samples], dtype=np.int64)
+                out["discard_mean_d"] = np.array([s["mean_d"] for s in samples], dtype=np.float32)
+                out["discard_se_d"] = np.array([s["se_d"] for s in samples], dtype=np.float32)
+        np.savez_compressed(
+            save_dir / f"shard_w{args.worker_id:02d}_{shard_idx:04d}.npz", **out)
+        buf = defaultdict(list)
+        shard_idx += 1
+
+    def pad(lst, fill, k=K):
+        lst = list(lst)[:k]
+        return lst + [fill] * (k - len(lst))
+
+    def record_seat0(decision, obs, mask, state, context):
+        action, ainfo = policy.get_action(obs, state, decision, context, mask)
+        sample = {"obs": obs, "act": int(action),
+                  "mask": np.asarray(mask, dtype=bool),
+                  "switched": bool(ainfo.get("switched", False))}
+        if decision == "discard":
+            sample["cands"] = pad(ainfo.get("candidates", [action]), -1)
+            sample["mean_d"] = pad(ainfo.get("mean_diffs", [0.0]), 0.0)
+            sample["se_d"] = pad(ainfo.get("se_diffs", [0.0]), 1e9)
+        buf[decision].append(sample)
+        return int(action)
+
+    def play_mixed(seed):
+        msg = sp_env.reset(seed=seed)
+        while True:
+            if msg["type"] == "game_over":
+                return float(msg["rewards"]["0"])
+            seat = int(msg["seat_id"])
+            decision, context = msg["decision"], msg.get("context", {})
+            obs = encode_state(msg["state"], version=3, context=context)
+            mask = get_action_mask(decision, context)
+            if seat == 0:
+                action = record_seat0(decision, obs, mask, msg["state"], context)
+            else:
+                action = pool_seat(seed, seat).select_action(
+                    obs, decision, mask, deterministic=True)
+            msg = sp_env.step(decision, int(action))
+
+    def play_heuristic(env, seed):
+        try:
+            obs, info = env.reset(seed=seed)
+        except AssertionError:
+            return None
+        while True:
+            action = record_seat0(info["decision"], obs,
+                                  info["action_mask"], info["state"],
+                                  info["context"])
+            obs, r, done, info = env.step(action)
+            if done:
+                return float(r)
+
+    for gi, seed in enumerate(my_seeds):
+        ttype = table_for(seed)
+        type_counts[ttype] += 1
+        if ttype == "mixed":
+            r = play_mixed(seed)
+        elif ttype == "ff":
+            r = play_heuristic(ff_env, seed)
+        else:
+            r = play_heuristic(ch_env, seed)
+        if r is not None:
+            game_rewards.append(r)
+
+        if (gi + 1) % args.games_per_shard == 0:
+            flush()
+        if (gi + 1) % 25 == 0:
+            rr = np.array(game_rewards)
+            print(f"[worker {args.worker_id}] {gi+1}/{len(my_seeds)} "
+                  f"seat0_money={rr.mean():+.2f} win%={np.mean(rr > 0):.1%} "
+                  f"switch={policy.n_switches}/{policy.n_discard_decisions} "
+                  f"({policy.n_switches / max(policy.n_discard_decisions,1):.1%}) "
+                  f"mix={dict(type_counts)} "
+                  f"| {(time.time()-t0)/(gi+1):.1f}s/game")
+            sys.stdout.flush()
+
+    flush()
+    rr = np.array(game_rewards)
+    print(f"[worker {args.worker_id}] DONE {len(my_seeds)} games "
+          f"seat0_money={rr.mean():+.2f} win%={np.mean(rr > 0):.1%} "
+          f"mix={dict(type_counts)}")
+    sp_env.close(); ff_env.close(); ch_env.close(); client.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Follow-on tooling from the AlphaZero work (#14), driven by a clear finding: **head-to-head money gates are intransitive and mislead promotion.**

## What's here

- **`rl/elo_ladder.py`** — paired round-robin over a checkpoint pool → one money-scale strength rating (weighted least-squares, mean 0), bootstrap 95% CIs, and an explicit **intransitivity residual**.
- **`rl/exit_datagen3.py`** — mixed-opponent ExIt datagen: seat 0 = champion + NN-guided search, opponents drawn from a *population* (net pool 55% / FirstFelix 30% / Chicken 15%) instead of champion copies. Fixes round-2 self-play specialization.

## The finding

Ladder over {r3, sp1b, D, imitation}, 2000 games/pair:

| rank | net | rating | 95% CI |
|---|---|---|---|
| 1 | D | +0.52 | [−0.13, +1.15] |
| 2 | r3 | +0.08 | [−0.56, +0.70] |
| 3 | sp1b | −0.20 | [−0.84, +0.45] |
| 4 | imit | −0.39 | [−1.04, +0.23] |

All CIs overlap; **intransitivity $0.65/game** (≈ the whole rating spread). The pairwise results form a cycle — sp1b>r3, D>sp1b, r3>D. On common-seed fixed anchors the three ExIt nets are within ~$0.5/game (r3 best vs FF, D best vs Chicken).

**Conclusion:** the r3→sp1b→D "climb" was pairwise-gate noise. Distillation-of-search has saturated; the three post-r3 nets are peers. The ladder is now the promotion gate, and the next real gain needs a stronger *teacher* (belief-state determinization + IS-MCTS, #13), not more distillation rounds.

Checkpoints and data stay gitignored. Ladder output: `rl/checkpoints/elo.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)