### PR TITLE
Belief-state opponent-hand determinization for the search (#17)

### DIFF
--- a/rl/TRAINING_HISTORY.md
+++ b/rl/TRAINING_HISTORY.md
@@ -790,3 +790,56 @@ benchmarks and by ladder rating the three are peers. Distillation-of-search has
 saturated. The ladder (rl/checkpoints/elo.md) is now the promotion gate. Next
 real lever = stronger teacher (belief-state determinization + IS-MCTS, #13),
 not more distill rounds.
+
+### Belief-state determinization (#13 lever 1) — GO signal (2026-07-09)
+Started the "stronger teacher" work. The search deals opponents' hidden tiles
+UNIFORMLY from the unseen pool; this tests whether a learned opponent model
+does better.
+- `BeliefDataGen.scala`: GameLogger hooks every discard, dumps (player's public
+  trail: own discards/melds/hand-size/wall → their TRUE 13-tile hand). 15k FF
+  games → 1.22M rows (`rl/data/belief_ff.jsonl`).
+- `belief_train.py`: small MLP (public trail → per-tile hold prob), vs the
+  uniform baseline the search uses today.
+
+**Result:** model recall@6 **55.3% vs uniform 24.1%** (+31pts), recall@10
+67.4% vs 31.1%, CE 2.836 vs 3.469. Opponent hands are strongly predictable from
+public discards — determinization is throwing away real signal. **GO to build
+belief-weighted world sampling into MCTSRolloutServer**, then A/B (belief vs
+uniform determinization) on net+search, then distil & ladder. (Necessary but
+not sufficient: payoff depends on whether better worlds change the search's
+picks and distil into a stronger net.)
+
+### Belief determinization wired into the search (#17) — built, A/B pending (2026-07-09)
+Implemented the belief-weighted world sampling (issue #17, lever 1 of #13):
+- `export_belief_onnx.py`: `ff.pt` → `rl/checkpoints/belief/ff.onnx`, graph
+  `feat(138)+avail(34)→probs(34)` with the avail mask baked in (parity 1.9e-6,
+  ~0.02ms/call).
+- `MCTSRolloutServer.scala`: opt-in `-Drl.belief=<onnx>`. `BeliefService` loads
+  the model; `beliefProbsPerOpp` builds each opponent's public-trail features
+  EXACTLY as `belief_train.load` (disc/4, meld planes, hand-size/13, wall/136;
+  avail = clip(4−disc−3·pong−4·kong−chow,0,4)) and queries once per decision
+  (fixed across worlds). `determinizeBelief` samples each opponent's hidden
+  tiles WITHOUT replacement from the unseen pool, weighting each type by
+  belief·copies-left; leftover → draw pile. Uniform stays the default/fallback;
+  determinization is computed once per world so CRN (paired candidates) holds.
+- Python: `MCTSRolloutClient(belief_model=…)`; `eval_mcts_ab.py --a-belief/--b-belief`.
+- Verified: `sbt assembly` clean; `test_mcts.py` (uniform path) all-pass; 8-game
+  A/B (FF/FF, belief arm B) runs end-to-end and arm B's discards diverge from
+  arm A → belief genuinely changes the search.
+
+**A/B GATE (FF/FF, 64 worlds, uniform vs belief determinization):**
+| batch | n | delta B−A |
+|-------|---|-----------|
+| run 1 | 400 | +2.49 ± 1.56 |
+| run 2 | 600 | +0.62 ± 1.21 |
+| **pooled** | **1000** | **+1.37 ± 0.96 (1.43σ), 95% CI [−0.50, +3.24]** |
+
+**VERDICT: gate NOT cleared.** The bigger second batch regressed the delta from
++2.49 → pooled +1.37/game; the CI still includes zero at 1000 paired games. The
+belief model reads hands far better (recall@6 55% vs 24%) but that converts to
+only a small, marginal money gain in the FF/FF search — the "necessary but not
+sufficient" caveat. Reaching 2σ at this effect needs ~1970 games (≈2× more
+compute) and would repeat the #15 mistake of promoting on noisy money numbers.
+**Did NOT proceed to ExIt-regen/distil/ladder.** Machinery (`-Drl.belief`,
+`ff.onnx`, A/B `--*-belief`) is committed and available if a future stronger
+belief model or a defense-specific test revives the lever.

--- a/rl/belief_train.py
+++ b/rl/belief_train.py
@@ -1,0 +1,146 @@
+"""
+belief_train.py — opponent hand-belief model + the go/no-go validation.
+
+Trains a small MLP to predict an opponent's true 13-tile dynamic hand from their
+PUBLIC trail (their discards, melds, hand size, wall remaining), then compares
+it head-to-head with the UNIFORM assumption the search currently makes when it
+determinizes hidden tiles.
+
+The decision metric: does the model concentrate probability on the tiles the
+opponent actually holds better than uniform? If top-k recall and cross-entropy
+beat uniform by a clear margin, belief-state determinization is worth building
+into MCTSRolloutServer. If not, uniform is fine and we drop the lever.
+
+    rl/venv/bin/python rl/belief_train.py --data rl/data/belief_ff.jsonl \
+        --out rl/checkpoints/belief/ff.pt
+"""
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+def load(path, limit=None):
+    disc, pong, kong, chow, scal, hand = [], [], [], [], [], []
+    with open(path) as fh:
+        for i, line in enumerate(fh):
+            if limit and i >= limit:
+                break
+            r = json.loads(line)
+            hs = r["hand_size"]
+            if hs <= 0:
+                continue
+            disc.append(r["disc"]); pong.append(r["pong"])
+            kong.append(r["kong"]); chow.append(r["chow"])
+            scal.append([hs / 13.0, r["remaining"] / 136.0])
+            hand.append(r["hand"])
+    disc = np.array(disc, np.float32); pong = np.array(pong, np.float32)
+    kong = np.array(kong, np.float32); chow = np.array(chow, np.float32)
+    scal = np.array(scal, np.float32); hand = np.array(hand, np.float32)
+    X = np.concatenate([disc / 4, pong, kong, chow, scal], axis=1)   # (N,138)
+    # tiles this player could still hold (their own copies not yet public)
+    avail = np.clip(4 - disc - 3 * pong - 4 * kong - chow, 0, 4).astype(np.float32)
+    return X, hand, avail
+
+
+class BeliefNet(nn.Module):
+    def __init__(self, in_dim=138, h=256):
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Linear(in_dim, h), nn.ReLU(),
+            nn.Linear(h, h), nn.ReLU(),
+            nn.Linear(h, 34))
+
+    def forward(self, x, avail):
+        logits = self.net(x)
+        logits = logits.masked_fill(avail <= 0, -30.0)  # can't hold unavailable
+        return logits
+
+
+def metrics(p, hand, avail, ks=(6, 10)):
+    """p: (N,34) prob dist; hand: true counts; avail: possible copies."""
+    hs = hand.sum(1, keepdim=True)
+    tgt = hand / hs.clamp(min=1)
+    ce = -(tgt * torch.log(p.clamp(min=1e-9))).sum(1).mean().item()
+    out = {"ce": ce}
+    # top-k recall: fraction of the opponent's tile-types captured in top-k
+    held = (hand > 0).float()
+    nheld = held.sum(1).clamp(min=1)
+    for k in ks:
+        topk = p.topk(k, dim=1).indices
+        hit = torch.gather(held, 1, topk).sum(1)
+        out[f"recall@{k}"] = (hit / nheld.clamp(max=k)).mean().item()
+    return out
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--data", required=True)
+    p.add_argument("--limit", type=int, default=None)
+    p.add_argument("--epochs", type=int, default=6)
+    p.add_argument("--batch-size", type=int, default=4096)
+    p.add_argument("--lr", type=float, default=1e-3)
+    p.add_argument("--device", default="cuda")
+    p.add_argument("--out", default="rl/checkpoints/belief/ff.pt")
+    args = p.parse_args()
+
+    t0 = time.time()
+    X, hand, avail = load(args.data, args.limit)
+    print(f"loaded {len(X):,} rows in {time.time()-t0:.0f}s")
+    n = len(X); nval = n // 20
+    perm = np.random.RandomState(0).permutation(n)
+    vi, ti = perm[:nval], perm[nval:]
+    dev = torch.device(args.device)
+
+    def to(idx):
+        return (torch.tensor(X[idx], device=dev),
+                torch.tensor(hand[idx], device=dev),
+                torch.tensor(avail[idx], device=dev))
+    Xv, Hv, Av = to(vi)
+
+    # ── Uniform baseline (what the search does now) ──────────────────────────
+    p_unif = (Av > 0).float() * Av
+    p_unif = p_unif / p_unif.sum(1, keepdim=True).clamp(min=1e-9)
+    base = metrics(p_unif, Hv, Av)
+    print(f"UNIFORM baseline:  ce={base['ce']:.3f}  "
+          f"recall@6={base['recall@6']:.1%}  recall@10={base['recall@10']:.1%}")
+
+    net = BeliefNet().to(dev)
+    opt = torch.optim.Adam(net.parameters(), lr=args.lr)
+    for ep in range(args.epochs):
+        net.train()
+        order = np.random.permutation(len(ti))
+        losses = []
+        for s in range(0, len(order), args.batch_size):
+            b = ti[order[s:s + args.batch_size]]
+            xb, hb, ab = to(b)
+            logits = net(xb, ab)
+            logp = F.log_softmax(logits, dim=1)
+            tgt = hb / hb.sum(1, keepdim=True).clamp(min=1)
+            loss = -(tgt * logp).sum(1).mean()
+            opt.zero_grad(); loss.backward(); opt.step()
+            losses.append(loss.item())
+        net.eval()
+        with torch.no_grad():
+            pv = F.softmax(net(Xv, Av), dim=1)
+            m = metrics(pv, Hv, Av)
+        print(f"epoch {ep+1}: loss={np.mean(losses):.3f}  MODEL ce={m['ce']:.3f}  "
+              f"recall@6={m['recall@6']:.1%}  recall@10={m['recall@10']:.1%}")
+
+    Path(args.out).parent.mkdir(parents=True, exist_ok=True)
+    torch.save({"net_state": net.state_dict()}, args.out)
+    print(f"\nsaved -> {args.out}")
+    print(f"VERDICT: model recall@6 {m['recall@6']:.1%} vs uniform "
+          f"{base['recall@6']:.1%}  (lift {m['recall@6']-base['recall@6']:+.1%}); "
+          f"ce {m['ce']:.3f} vs {base['ce']:.3f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/rl/eval_mcts_ab.py
+++ b/rl/eval_mcts_ab.py
@@ -33,7 +33,7 @@ _W = {}
 
 
 def _worker_init(jar, checkpoint, nn_model, n_worlds, top_k, z, min_gain,
-                 a_self, a_opp, b_self, b_opp, threads):
+                 a_self, a_opp, b_self, b_opp, threads, a_belief, b_belief):
     import torch
     torch.set_num_threads(1)
     from env import MahjongEnv
@@ -42,18 +42,19 @@ def _worker_init(jar, checkpoint, nn_model, n_worlds, top_k, z, min_gain,
 
     agent = MahjongAgent.load(checkpoint, device="cpu")
 
-    def make_policy(self_pol, opp_pol):
+    def make_policy(self_pol, opp_pol, belief):
         client = MCTSRolloutClient(
             jar_path=jar, rollout_opp=opp_pol,
             nn_model=nn_model if "nn" in (self_pol, opp_pol) else None,
+            belief_model=belief,
             rollout_threads=threads)
         return PairedMCTSPolicy(
             net=agent.net, rollout_client=client,
             n_worlds=n_worlds, top_k=top_k, z_threshold=z,
             min_gain=min_gain, device="cpu", self_policy=self_pol)
 
-    _W["policies"] = {"A": make_policy(a_self, a_opp),
-                      "B": make_policy(b_self, b_opp)}
+    _W["policies"] = {"A": make_policy(a_self, a_opp, a_belief),
+                      "B": make_policy(b_self, b_opp, b_belief)}
     _W["env"] = MahjongEnv(jar, opponent="firstfelix", obs_version=3)
 
 
@@ -86,6 +87,10 @@ def main():
     p.add_argument("--a-opp", default="firstfelix")
     p.add_argument("--b-self", default="nn")
     p.add_argument("--b-opp", default="firstfelix")
+    p.add_argument("--a-belief", default=None,
+                   help="belief ONNX for arm A's determinization (default: uniform)")
+    p.add_argument("--b-belief", default=None,
+                   help="belief ONNX for arm B's determinization (default: uniform)")
     p.add_argument("--n-games", type=int, default=400)
     p.add_argument("--n-workers", type=int, default=5)
     p.add_argument("--n-worlds", type=int, default=64)
@@ -104,7 +109,7 @@ def main():
         initargs=(args.jar, args.checkpoint, args.nn_model, args.n_worlds,
                   args.top_k, args.z_threshold, args.min_gain,
                   args.a_self, args.a_opp, args.b_self, args.b_opp,
-                  args.rollout_threads),
+                  args.rollout_threads, args.a_belief, args.b_belief),
     ) as pool:
         for res in pool.map(_play_seed, seeds, chunksize=2):
             results.append(res)

--- a/rl/export_belief_onnx.py
+++ b/rl/export_belief_onnx.py
@@ -1,0 +1,103 @@
+"""
+export_belief_onnx.py — Export a trained opponent hand-belief model (BeliefNet)
+to ONNX for use inside the Scala rollout server (ONNX Runtime Java).
+
+The graph takes a batch of two inputs:
+
+    feat  (B, 138)  public-trail features, EXACTLY as belief_train.load builds
+                    them: concat(disc/4, pong, kong, chow, [hand_size/13,
+                    remaining/136]).
+    avail (B, 34)   per-tile copies this opponent could still hold
+                    (clip(4 - disc - 3*pong - 4*kong - chow, 0, 4)).
+
+and returns:
+
+    probs (B, 34)   softmax over tile types of the (avail-masked) logits — the
+                    per-tile-type hold distribution the search uses to weight
+                    opponent-hand determinization.
+
+Masking is baked into the graph (logits.masked_fill(avail<=0, -30)) so the
+Scala side only has to supply the two feature tensors and read one output.
+
+Usage
+─────
+    rl/venv/bin/python rl/export_belief_onnx.py \
+        --checkpoint rl/checkpoints/belief/ff.pt \
+        --out rl/checkpoints/belief/ff.onnx
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from belief_train import BeliefNet
+
+
+class BeliefProbs(nn.Module):
+    """Wraps BeliefNet: masked logits → softmax probability distribution."""
+
+    def __init__(self, net):
+        super().__init__()
+        self.net = net
+
+    def forward(self, feat, avail):
+        logits = self.net(feat, avail)          # already masked_fill(avail<=0, -30)
+        return F.softmax(logits, dim=1)
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--checkpoint", default="rl/checkpoints/belief/ff.pt")
+    p.add_argument("--out", default="rl/checkpoints/belief/ff.onnx")
+    args = p.parse_args()
+
+    ckpt = torch.load(args.checkpoint, map_location="cpu")
+    net = BeliefNet()
+    net.load_state_dict(ckpt["net_state"])
+    net.eval()
+    wrapper = BeliefProbs(net).eval()
+
+    dummy_feat = torch.zeros(1, 138, dtype=torch.float32)
+    dummy_avail = torch.full((1, 34), 4.0, dtype=torch.float32)
+    torch.onnx.export(
+        wrapper, (dummy_feat, dummy_avail), args.out,
+        input_names=["feat", "avail"],
+        output_names=["probs"],
+        dynamic_axes={"feat": {0: "batch"}, "avail": {0: "batch"},
+                      "probs": {0: "batch"}},
+        opset_version=17,
+    )
+
+    # parity check vs PyTorch on random inputs
+    import onnxruntime as ort
+    sess = ort.InferenceSession(args.out, providers=["CPUExecutionProvider"])
+    rng = np.random.default_rng(0)
+    feat = rng.random((64, 138), dtype=np.float32)
+    avail = rng.integers(0, 5, (64, 34)).astype(np.float32)
+    ort_out = sess.run(None, {"feat": feat, "avail": avail})[0]
+    with torch.no_grad():
+        pt_out = wrapper(torch.tensor(feat), torch.tensor(avail)).numpy()
+    max_err = float(np.abs(ort_out - pt_out).max())
+    print(f"exported {args.out}  max |onnx - torch| = {max_err:.2e}")
+    assert max_err < 1e-4, "ONNX output mismatch"
+
+    import time
+    for bs in (1, 3, 16):
+        x_f, x_a = feat[:bs], avail[:bs]
+        t0 = time.time()
+        n_iter = 500
+        for _ in range(n_iter):
+            sess.run(None, {"feat": x_f, "avail": x_a})
+        dt = (time.time() - t0) / n_iter * 1000
+        print(f"  batch {bs:>3}: {dt:.3f} ms/call")
+
+
+if __name__ == "__main__":
+    main()

--- a/rl/mcts.py
+++ b/rl/mcts.py
@@ -76,12 +76,17 @@ class MCTSRolloutClient:
         java_bin: str = "java",
         nn_model: Optional[str] = None,
         rollout_threads: int = 1,
+        belief_model: Optional[str] = None,
     ) -> None:
         self.n_rollouts  = n_rollouts
         self.rollout_opp = rollout_opp
         extra = []
         if nn_model is not None:
             extra.append(f"-Drl.nnmodel={nn_model}")
+        if belief_model is not None:
+            # Opt in to belief-weighted opponent-hand determinization; without
+            # this flag the server falls back to the uniform shuffle-and-deal.
+            extra.append(f"-Drl.belief={belief_model}")
         if rollout_threads > 1:
             extra.append(f"-Drl.rolloutThreads={rollout_threads}")
         self._proc = subprocess.Popen(

--- a/src/main/scala-2.12/io/fele/app/mahjong/rl/BeliefDataGen.scala
+++ b/src/main/scala-2.12/io/fele/app/mahjong/rl/BeliefDataGen.scala
@@ -1,0 +1,115 @@
+package io.fele.app.mahjong.rl
+
+import java.io.{BufferedWriter, FileWriter}
+
+import io.fele.app.mahjong._
+import io.fele.app.mahjong.player.{Chicken, FirstFelix, Player}
+import org.json4s._
+import org.json4s.native.Serialization
+import org.json4s.native.Serialization.write
+
+import scala.util.{Random, Try}
+
+/**
+ * BeliefDataGen — training data for the opponent hand-belief model.
+ *
+ * Plays full games with a fixed opponent policy (default FirstFelix, the policy
+ * our search uses in rollouts) and, at every discard, records one row from the
+ * PUBLIC view of the discarding player plus their TRUE hidden hand as the label:
+ *
+ *   { "pid":         seat id,
+ *     "hand_size":   dynamic tiles held (13 - 3*melds),
+ *     "remaining":   tiles left in the wall,
+ *     "disc":        [34] this player's own discards so far (incl. this tile),
+ *     "pong":[34], "kong":[34], "chow":[34]  this player's melds,
+ *     "hand":        [34] TRUE dynamic hand counts (the label to predict) }
+ *
+ * The tile just discarded is already out of hand at the logger callback, so
+ * `hand` is the post-discard 13-tile state — exactly what the search must guess
+ * for an opponent between their turns.
+ *
+ * Usage:
+ *   java -Drl.beliefout=belief.jsonl -Drl.beliefgames=20000 \
+ *        -Drl.beliefopp=firstfelix -Drl.beliefseed=0 \
+ *        -cp <jar> io.fele.app.mahjong.rl.BeliefDataGen
+ */
+object BeliefDataGen extends App {
+
+  implicit val formats: Formats = Serialization.formats(NoTypeHints)
+  implicit val config: Config = new Config()
+
+  private val outPath = System.getProperty("rl.beliefout", "belief.jsonl")
+  private val nGames  = Integer.getInteger("rl.beliefgames", 10000)
+  private val oppType = System.getProperty("rl.beliefopp", "firstfelix").toLowerCase
+  private val seed0   = Integer.getInteger("rl.beliefseed", 0).toLong
+
+  private def counts(tiles: Seq[Tile]): Array[Int] = {
+    val a = Array.fill(34)(0)
+    tiles.foreach(t => a(t.toTileValue) += 1)
+    a
+  }
+
+  private def meldPlanes(groups: List[TileGroup]): (Array[Int], Array[Int], Array[Int]) = {
+    val pong = Array.fill(34)(0); val kong = Array.fill(34)(0); val chow = Array.fill(34)(0)
+    groups.foreach {
+      case PongGroup(t)  => pong(t.toTileValue) = 1
+      case KongGroup(t)  => kong(t.toTileValue) = 1
+      case ChowGroup(ts) => ts.foreach(t => chow(t.toTileValue) = 1)
+    }
+    (pong, kong, chow)
+  }
+
+  /** GameLogger that snapshots a belief-training row at every discard. */
+  private class BeliefLogger(gameState: GameState, out: BufferedWriter) extends GameLogger {
+    override def start(): Unit = ()
+    override def resume(): Unit = ()
+    override def kong(e: KongEvent): Unit = ()
+    override def pong(e: PongEvent): Unit = ()
+    override def chow(e: ChowEvent): Unit = ()
+    override def draw(e: DrawEvent): Unit = ()
+    override def end(e: EndEvent): Unit = ()
+
+    override def discard(e: DiscardEvent): Unit = {
+      val p = gameState.players(e.playerId)
+      val dynamic = p.hand.dynamicTiles           // already post-discard (13-3*melds)
+      // this player's own discards so far + the tile just thrown
+      val myDisc = counts(
+        gameState.discards.filter(_.playerId == e.playerId).map(_.tile))
+      myDisc(e.tile.toTileValue) += 1
+      val (pong, kong, chow) = meldPlanes(p.hand.fixedTileGroups)
+      val row = Map(
+        "pid"       -> e.playerId,
+        "hand_size" -> dynamic.size,
+        "remaining" -> gameState.drawer.remainingTiles.size,
+        "disc"      -> myDisc.toList,
+        "pong"      -> pong.toList,
+        "kong"      -> kong.toList,
+        "chow"      -> chow.toList,
+        "hand"      -> counts(dynamic).toList
+      )
+      out.write(write(row)); out.write("\n")
+    }
+  }
+
+  private def makePlayer(id: Int, tiles: List[Tile]): Player = oppType match {
+    case "chicken" => new Chicken(id, tiles)
+    case _         => new FirstFelix(id, tiles, 5)
+  }
+
+  val out = new BufferedWriter(new FileWriter(outPath))
+  var rows = 0L
+  var gi = 0
+  while (gi < nGames) {
+    val seed = seed0 + gi
+    val drawer: TileDrawer = new RandomTileDrawer(Some(seed))
+    val players: List[Player] = (0 to 3).map(i => makePlayer(i, drawer.popHand())).toList
+    val state = GameState(players, None, Nil, (seed % 4).toInt, drawer)
+    val logger: GameLogger = new BeliefLogger(state, out)
+    val flow = new FlowImpl(state)(logger)
+    Try(flow.start())
+    gi += 1
+    if (gi % 2000 == 0) { out.flush(); System.err.println(s"[belief] $gi/$nGames games") }
+  }
+  out.flush(); out.close()
+  System.err.println(s"[belief] DONE $nGames games -> $outPath")
+}

--- a/src/main/scala-2.12/io/fele/app/mahjong/rl/MCTSRolloutServer.scala
+++ b/src/main/scala-2.12/io/fele/app/mahjong/rl/MCTSRolloutServer.scala
@@ -50,6 +50,13 @@ object MCTSRolloutServer extends App {
     new OnnxPolicyService(path)
   }
 
+  // Opponent hand-belief model (opt-in via -Drl.belief=<path.onnx>). When set,
+  // opponents' hidden hands are determinized by belief-weighted sampling from
+  // the unseen pool instead of a uniform shuffle. Uniform stays the fallback.
+  private val beliefPath = System.getProperty("rl.belief")
+  private lazy val beliefService: BeliefService = new BeliefService(beliefPath)
+  private def beliefEnabled: Boolean = beliefPath != null
+
   // Parallel world evaluation (-Drl.rolloutThreads=N)
   private lazy val rolloutPool = java.util.concurrent.Executors.newFixedThreadPool(
     Integer.getInteger("rl.rolloutThreads", 1))
@@ -113,29 +120,82 @@ object MCTSRolloutServer extends App {
     case _            => new Chicken(seat, dyn, grps)
   }
 
-  private def runRollout(
-    myDynamic:   List[Tile],
-    myGroups:    List[TileGroup],
-    oppGroups:   List[List[TileGroup]],  // 3 opponents (relative seats 1-3)
-    discardTile: Tile,
-    unknown:     Seq[Tile],              // shuffled pool to split
-    remaining:   Int,                   // tiles to assign to draw pile
-    oppPolicy:   String,                // "chicken" | "firstfelix" | "nn"
-    selfPolicy:  String,                // "chicken" | "firstfelix" | "nn"
-    preDiscards: List[DiscardInfo] = Nil // real discard history (NN policies read it)
-  ): Double = {
-
-    // --- Distribute unknown tiles ---
-    // First `remaining` tiles → draw pile; rest → opponents' dynamic hands
-    val drawPile  = unknown.take(remaining)
-    var oppHidden = unknown.drop(remaining).toList
-
-    val oppDynamic: List[List[Tile]] = oppGroups.map { grps =>
+  /** Uniform determinization: split a shuffled unseen pool into draw pile +
+    * opponents' hidden hands (the search's default behaviour). */
+  private def determinizeUniform(
+    st: ParsedState, remaining: Int, rng: Random
+  ): (List[List[Tile]], Seq[Tile]) = {
+    val shuffled  = rng.shuffle(st.unknownBase)
+    val drawPile  = shuffled.take(remaining)
+    var oppHidden = shuffled.drop(remaining).toList
+    val oppDynamic = st.oppGroups.map { grps =>
       val nDynamic = Math.max(0, 13 - 3 * grps.size)
       val chunk    = oppHidden.take(nDynamic)
       oppHidden    = oppHidden.drop(nDynamic)
       chunk
     }
+    (oppDynamic, drawPile)
+  }
+
+  /** Belief-weighted determinization: for each opponent, sample their hidden
+    * tiles from the unseen pool WITHOUT replacement, weighting each remaining
+    * tile type by beliefProbs(i)(type) × copies-left. Leftover pool → draw pile. */
+  private def determinizeBelief(
+    st: ParsedState, remaining: Int, beliefProbs: Array[Array[Float]], rng: Random
+  ): (List[List[Tile]], Seq[Tile]) = {
+    val pool = Array.fill[Int](34)(0)
+    st.unknownBase.foreach(t => pool(t.toTileValue) += 1)
+
+    val oppDynamic = st.oppGroups.zipWithIndex.map { case (grps, i) =>
+      val nDynamic = Math.max(0, 13 - 3 * grps.size)
+      val probs    = beliefProbs(i)
+      val buf      = new scala.collection.mutable.ListBuffer[Tile]
+      var drawn    = 0
+      while (drawn < nDynamic) {
+        var total = 0.0
+        var t = 0
+        val w = new Array[Double](34)
+        while (t < 34) {
+          w(t)   = pool(t).toDouble * math.max(1e-6, probs(t).toDouble)
+          total += w(t)
+          t += 1
+        }
+        if (total <= 0.0) drawn = nDynamic          // pool exhausted; bail out
+        else {
+          var r = rng.nextDouble() * total
+          var chosen = -1
+          t = 0
+          while (t < 34 && chosen < 0) {
+            r -= w(t)
+            if (r <= 0.0 && pool(t) > 0) chosen = t
+            t += 1
+          }
+          if (chosen < 0) {                           // numerical guard: last non-empty
+            t = 33; while (t >= 0 && chosen < 0) { if (pool(t) > 0) chosen = t; t -= 1 }
+          }
+          pool(chosen) -= 1
+          buf += Tile.fromValue(chosen)
+          drawn += 1
+        }
+      }
+      buf.toList
+    }
+
+    val leftover = (0 until 34).flatMap(id => List.fill(pool(id))(Tile.fromValue(id)))
+    (oppDynamic, rng.shuffle(leftover))
+  }
+
+  private def runRollout(
+    myDynamic:   List[Tile],
+    myGroups:    List[TileGroup],
+    oppGroups:   List[List[TileGroup]],  // 3 opponents (relative seats 1-3)
+    discardTile: Tile,
+    oppDynamic:  List[List[Tile]],       // determinized opponent hidden hands
+    drawPile:    Seq[Tile],              // determinized draw pile
+    oppPolicy:   String,                // "chicken" | "firstfelix" | "nn"
+    selfPolicy:  String,                // "chicken" | "firstfelix" | "nn"
+    preDiscards: List[DiscardInfo] = Nil // real discard history (NN policies read it)
+  ): Double = {
 
     // Verify hand sizes are valid; skip rollout if not
     val handsOk = (0 until 3).forall { i =>
@@ -236,6 +296,59 @@ object MCTSRolloutServer extends App {
         }
     }
 
+  /** Raw 4×34 per-player discard counts in rollout seat order (0 = us). */
+  private def parseDiscByPlayer(cmd: Map[String, Any]): Array[Array[Int]] =
+    cmd.get("discards_by_player") match {
+      case Some(raw) => asList(raw).map(row => asList(row).map(asInt).toArray).toArray
+      case None      => Array.fill(4)(new Array[Int](34))
+    }
+
+  /** 0/1 meld planes for one opponent's fixed groups (matches BeliefDataGen). */
+  private def meldPlanes(groups: List[TileGroup]): (Array[Float], Array[Float], Array[Float]) = {
+    val pong = new Array[Float](34); val kong = new Array[Float](34); val chow = new Array[Float](34)
+    groups.foreach {
+      case PongGroup(t)  => pong(t.toTileValue) = 1f
+      case KongGroup(t)  => kong(t.toTileValue) = 1f
+      case ChowGroup(ts) => ts.foreach(t => chow(t.toTileValue) = 1f)
+    }
+    (pong, kong, chow)
+  }
+
+  /** Per-opponent belief distribution over held tile types, computed once for a
+    * decision (the public trail is fixed across worlds). Features/masking mirror
+    * belief_train.load exactly: feat = concat(disc/4, pong, kong, chow,
+    * [hand_size/13, remaining/136]); avail = clip(4 - disc - 3*pong - 4*kong - chow, 0, 4).
+    * `discByPlayer` is 4×34 in rollout seat order (0 = us, 1-3 = opp_groups order). */
+  private def beliefProbsPerOpp(
+    st: ParsedState, discByPlayer: Array[Array[Int]], remaining: Int
+  ): Array[Array[Float]] =
+    st.oppGroups.zipWithIndex.map { case (grps, i) =>
+      val disc = if (i + 1 < discByPlayer.length) discByPlayer(i + 1) else new Array[Int](34)
+      val (pong, kong, chow) = meldPlanes(grps)
+      val handSize = Math.max(0, 13 - 3 * grps.size)
+
+      val feat = new Array[Float](138)
+      var t = 0
+      while (t < 34) {
+        feat(t)        = disc(t) / 4f
+        feat(34 + t)   = pong(t)
+        feat(68 + t)   = kong(t)
+        feat(102 + t)  = chow(t)
+        t += 1
+      }
+      feat(136) = handSize / 13f
+      feat(137) = remaining / 136f
+
+      val avail = new Array[Float](34)
+      t = 0
+      while (t < 34) {
+        val a = 4f - disc(t) - 3f * pong(t) - 4f * kong(t) - chow(t)
+        avail(t) = math.max(0f, math.min(4f, a))
+        t += 1
+      }
+      beliefService.query(feat, avail)
+    }.toArray
+
   // ── Main server loop ─────────────────────────────────────────────────────────
 
   while (true) {
@@ -255,10 +368,15 @@ object MCTSRolloutServer extends App {
         val discardTile = Tile.fromValue(discardTileId)
         val myDynamic   = st.dynamicAfterDiscard(discardTileId)
 
+        val beliefProbs =
+          if (beliefEnabled) beliefProbsPerOpp(st, parseDiscByPlayer(cmd), st.actualRemaining)
+          else null
         val rewards = (0 until nRollouts).map { _ =>
-          val shuffled = rng.shuffle(st.unknownBase)
-          runRollout(myDynamic, st.myGroups, st.oppGroups, discardTile, shuffled,
-                     st.actualRemaining, oppPolicy, selfPolicy, preDiscards)
+          val (oppDynamic, drawPile) =
+            if (beliefEnabled) determinizeBelief(st, st.actualRemaining, beliefProbs, rng)
+            else determinizeUniform(st, st.actualRemaining, rng)
+          runRollout(myDynamic, st.myGroups, st.oppGroups, discardTile, oppDynamic, drawPile,
+                     oppPolicy, selfPolicy, preDiscards)
         }.toList
 
         val n    = rewards.size.toDouble
@@ -290,15 +408,25 @@ object MCTSRolloutServer extends App {
         // rewards(k)(c) = reward of candidate c in world k.
         // Worlds run in parallel (-Drl.rolloutThreads=N); the shuffles are
         // drawn sequentially up front so results don't depend on scheduling.
+        // Belief distributions are fixed for this decision (public trail doesn't
+        // vary across worlds) → compute once, reuse in every world's sampling.
+        val beliefProbs =
+          if (beliefEnabled) beliefProbsPerOpp(st, parseDiscByPlayer(cmd), st.actualRemaining)
+          else null
+
         val worldSeeds = (0 until nWorlds).map(_ => rng.nextLong())
         val tasks = new java.util.ArrayList[java.util.concurrent.Callable[List[Double]]]()
         worldSeeds.foreach { seed =>
           tasks.add(new java.util.concurrent.Callable[List[Double]] {
             override def call(): List[Double] = {
-              val shuffled = new Random(seed).shuffle(st.unknownBase)
+              // One determinization per world, shared by all candidates (CRN).
+              val wr = new Random(seed)
+              val (oppDynamic, drawPile) =
+                if (beliefEnabled) determinizeBelief(st, st.actualRemaining, beliefProbs, wr)
+                else determinizeUniform(st, st.actualRemaining, wr)
               candTiles.zip(candDynamic).map { case (tile, dyn) =>
-                runRollout(dyn, st.myGroups, st.oppGroups, tile, shuffled,
-                           st.actualRemaining, oppPolicy, selfPolicy, preDiscards)
+                runRollout(dyn, st.myGroups, st.oppGroups, tile, oppDynamic, drawPile,
+                           oppPolicy, selfPolicy, preDiscards)
               }
             }
           })

--- a/src/main/scala-2.12/io/fele/app/mahjong/rl/NNRollout.scala
+++ b/src/main/scala-2.12/io/fele/app/mahjong/rl/NNRollout.scala
@@ -200,6 +200,35 @@ class OnnxPolicyService(modelPath: String, maxBatch: Int = 256) {
   }
 }
 
+/**
+ * Opponent hand-belief model (see rl/belief_train.py / export_belief_onnx.py).
+ *
+ * Given an opponent's public trail it returns a 34-length probability
+ * distribution over the tile types they are likely still holding. The search
+ * uses these to weight determinization of hidden hands, replacing the uniform
+ * shuffle-and-deal. Inference is cheap (~0.02ms) and each opponent's belief is
+ * fixed for a decision, so it is queried once per opponent per batch.
+ */
+class BeliefService(modelPath: String) {
+  private val env = OrtEnvironment.getEnvironment
+  private val opts = new OrtSession.SessionOptions()
+  opts.setIntraOpNumThreads(1)
+  private val session = env.createSession(modelPath, opts)
+
+  /** feat: 138 public-trail features, avail: 34 holdable-copy counts → 34 probs. */
+  def query(feat: Array[Float], avail: Array[Float]): Array[Float] = synchronized {
+    val ft = OnnxTensor.createTensor(
+      env, java.nio.FloatBuffer.wrap(feat), Array(1L, feat.length.toLong))
+    val at = OnnxTensor.createTensor(
+      env, java.nio.FloatBuffer.wrap(avail), Array(1L, avail.length.toLong))
+    val inputs = new java.util.HashMap[String, OnnxTensor]()
+    inputs.put("feat", ft); inputs.put("avail", at)
+    val out = session.run(inputs)
+    try out.get(0).getValue.asInstanceOf[Array[Array[Float]]](0).clone()
+    finally { out.close(); ft.close(); at.close() }
+  }
+}
+
 /** Rollout player driven by greedy masked argmax over the network heads. */
 class NNPlayer(id: Int, tiles: List[Tile], tileGroups: List[TileGroup],
                svc: OnnxPolicyService)(implicit c: Config)


### PR DESCRIPTION
Implements **lever 1 of #13** (issue #17): replaces the uniform shuffle-and-deal the MCTS rollout server used to determinize opponents' hidden tiles with **belief-weighted sampling** from a learned opponent-hand model.

## What's in here

- **`rl/BeliefDataGen.scala`** — `GameLogger` dumping `(public trail → true 13-tile hand)` rows from FF self-play.
- **`rl/belief_train.py`** — small MLP (trail → per-tile hold prob) + the uniform baseline. **recall@6 55.3% vs uniform 24.1%.**
- **`rl/export_belief_onnx.py`** — `ff.pt → ff.onnx` (`feat[138]+avail[34] → probs[34]`), avail mask baked into the graph, parity 1.9e-6.
- **`MCTSRolloutServer.scala` / `NNRollout.scala`** — opt-in `-Drl.belief=<onnx>`. `BeliefService` (ONNX-in-Scala), `beliefProbsPerOpp` (features mirror `belief_train.load` byte-for-byte, queried once per decision), `determinizeBelief` (weighted sampling without replacement from the unseen pool, computed once per world so the paired-candidate CRN property holds). **Uniform stays the default and fallback.**
- **`mcts.py` / `eval_mcts_ab.py`** — `belief_model` passthrough + `--a-belief/--b-belief`.

## A/B gate result

FF/FF rollouts, 64 worlds, uniform (arm A) vs belief (arm B), paired seeds:

| batch | n | delta B−A |
|-------|---|-----------|
| run 1 | 400 | +2.49 ± 1.56 |
| run 2 | 600 | +0.62 ± 1.21 |
| **pooled** | **1000** | **+1.37 ± 0.96 (1.43σ), 95% CI [−0.50, +3.24]** |

**Gate NOT cleared.** The belief model reads opponent hands far better (recall 55% vs 24%), but the money gain in the FF/FF search is small and not statistically separable from zero at 1000 paired games — the "necessary but not sufficient" caveat. Per #15's gate discipline (don't promote on noisy money numbers), this did **not** trigger the expensive ExIt-regen → distil → ladder round.

This PR **lands the machinery** (fully built, tested — `sbt assembly` clean, `test_mcts.py` all-pass, uniform path unchanged) so the lever can be revived cheaply with a stronger belief model or a defense-specific test. Full story in `rl/TRAINING_HISTORY.md`.

Closes #17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Trhd7WMpdiupNbCZowCGQg