### PR TITLE
rl: lever re-audit infra + exhaustive off-FF sweep (ceiling confirmed)

### DIFF
--- a/rl/TRAINING_HISTORY.md
+++ b/rl/TRAINING_HISTORY.md
@@ -843,3 +843,36 @@ compute) and would repeat the #15 mistake of promoting on noisy money numbers.
 **Did NOT proceed to ExIt-regen/distil/ladder.** Machinery (`-Drl.belief`,
 `ff.onnx`, A/B `--*-belief`) is committed and available if a future stronger
 belief model or a defense-specific test revives the lever.
+
+### Lever re-audit + exhaustive off-FF sweep (2026-07-16→20) — CEILING CONFIRMED
+Motivation: every shelved quality lever (belief #17, rollout-realism #25, danger
+#21/#22, deeper search #24) improves DEFENSE / opponent-modeling, and ALL were
+gated only vs 3×FirstFelix — where FF is too weak to punish deal-ins AND
+FF-rollouts are oracle-correct, so defensive value is structurally invisible.
+Hypothesis: the "ceiling" was partly a benchmark artifact; re-test off FF on
+self-play MIXED tables (seat0=champion+search, seats1-3=NN pool). New tooling:
+`eval_teacher_mixed.py` (paired mixed-table A/B, per-arm rollout_opp/nn_model/
+belief), `BeliefDataGen` `-Drl.beliefopp=nn`, value-corpus logging in
+`exit_datagen3.py` (`discard_balance`), GPU `value_train.py`.
+
+Results — the confound was REAL but the levers still don't convert:
+- **Belief (#17) re-powered:** NN-opponent belief model trained (1.07M rows),
+  recall@6 51.0% vs uniform 27.5% — mechanism validated for strong opponents.
+  But belief-on/off A/B on mixed tables: **−1.65±1.44/game (n=600)** — neutral-
+  to-negative. Mechanism-validation-not-sufficient, 3rd time.
+- **Rollout-realism (#25) re-test on mixed tables:** nn vs ff rollout opp
+  converged to **−0.45±2.55 (n=150)** — null (nn-rollout uses one greedy student
+  for all opps, a worse rollout policy than fast consistent FF).
+- **Data-scale/league round:** 13.2k mixed games → `exit_mix2_soft`. Head-to-head
+  vs D +1.91±1.12 BUT fixed anchors refute: vs FF −0.63±0.66 (worse), vs Chicken
+  −0.09 (tied). 3rd head-to-head mislead → NO promotion.
+- **Value-leaf (#20):** 270k on-distribution corpus → value net R² 0.58→**0.788**,
+  but RMS ~$12.5 (vs prior $14, −11%) — nowhere near the ≪$2 sibling-bias bar.
+- **top_k pruning:** top6 vs top12 **+0.68±1.75 (n=400)** — null.
+- **self-tail strength:** student vs champion self-continuation **+0.27±4.06
+  (n=120)** — null.
+
+**CONCLUSION: the distill-from-search agent is at its true ceiling** — not a
+measurement artifact. Champion unchanged since net D (`best_raw_net.pt`,
+2026-07-09). Search/data levers are exhausted; further gains need a different
+paradigm or a different objective (human-facing product = the active track).

--- a/rl/eval_teacher_mixed.py
+++ b/rl/eval_teacher_mixed.py
@@ -1,0 +1,154 @@
+"""
+eval_teacher_mixed.py — paired teacher A/B on MIXED (NN-opponent) tables.
+
+The FF-anchored gates (#24 depth, #25 rollout, #22 danger) all measured levers
+against 3xFirstFelix, where FF-rollouts are oracle-correct and defense is
+invisible. This harness runs the SAME paired-CRN teacher on the production
+self-play mixed table (seat 0 = champion + search; seats 1-3 = NN pool nets),
+so opponent-model realism can actually pay off.
+
+Two arms, SAME net, differ only in (rollout_opp, nn_model). Paired by seed:
+identical deal + identical pool opponents for both arms; trajectories diverge
+only where seat 0's search picks differently. Reports paired seat-0 money delta.
+
+Rollout-realism test (does modelling opponents as NN beat modelling them as FF
+when they ARE NN?):
+    rl/venv/bin/python rl/eval_teacher_mixed.py \
+        --checkpoint rl/checkpoints/best_raw_net.pt \
+        --a-rollout-opp firstfelix --b-rollout-opp nn \
+        --a-nn-model rl/checkpoints/student/student48_sp1b.onnx \
+        --b-nn-model rl/checkpoints/student/student48_sp1b.onnx \
+        --pool rl/checkpoints/exit_sp1b_soft/exit_final.pt ... best_raw_net.pt \
+        --n-games 400 --n-workers 4
+
+Self-tail test (does a stronger self-continuation policy in rollouts help?):
+    ... --a-rollout-opp firstfelix --b-rollout-opp firstfelix \
+        --a-nn-model .../student48_sp1b.onnx --b-nn-model .../best_raw_net.onnx
+"""
+
+import argparse
+import sys
+import time
+from concurrent.futures import ProcessPoolExecutor
+from pathlib import Path
+
+import numpy as np
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+_W = {}
+
+
+def _worker_init(jar, ckpt, a_ropp, b_ropp, a_nn, b_nn, a_belief, b_belief,
+                 pool_paths, n_worlds, top_k, z, min_gain, threads):
+    import torch
+    torch.set_num_threads(1)
+    from env import encode_state, get_action_mask  # noqa: F401
+    from model import MahjongAgent
+    from mcts import MCTSRolloutClient, PairedMCTSPolicy
+    from self_play import TrueSelfPlayEnv
+
+    agent = MahjongAgent.load(ckpt, device="cpu")
+    assert agent.net.obs_dim == 759, "expects a v3 net"
+    pool = [MahjongAgent.load(c, device="cpu") for c in pool_paths]
+
+    def build(ropp, nn, belief):
+        client = MCTSRolloutClient(jar_path=jar, rollout_opp=ropp, nn_model=nn,
+                                   belief_model=belief, rollout_threads=threads)
+        return PairedMCTSPolicy(
+            net=agent.net, rollout_client=client, n_worlds=n_worlds,
+            top_k=top_k, z_threshold=z, min_gain=min_gain, device="cpu",
+            self_policy="nn")
+
+    _W.update(A=build(a_ropp, a_nn, a_belief), B=build(b_ropp, b_nn, b_belief),
+              pool=pool, sp=TrueSelfPlayEnv(jar))
+
+
+def _play_arm(arm, seed):
+    from env import encode_state, get_action_mask
+    sp, policy, pool = _W["sp"], _W[arm], _W["pool"]
+    msg = sp.reset(seed=seed)
+    while True:
+        if msg["type"] == "game_over":
+            return float(msg["rewards"]["0"])
+        seat = int(msg["seat_id"])
+        decision, context = msg["decision"], msg.get("context", {})
+        obs = encode_state(msg["state"], version=3, context=context)
+        mask = get_action_mask(decision, context)
+        if seat == 0:
+            action, _ = policy.get_action(obs, msg["state"], decision, context, mask)
+        else:
+            net = pool[(seed * 7 + seat * 101) % len(pool)]
+            action = net.select_action(obs, decision, mask, deterministic=True)
+        msg = sp.step(decision, int(action))
+
+
+def _play_seed(seed):
+    # same seed => identical deal + identical pool opponents for both arms
+    return {"A": _play_arm("A", seed), "B": _play_arm("B", seed)}
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--jar", default="target/scala-2.12/mahjong-assembly-0.1.0.jar")
+    p.add_argument("--checkpoint", required=True, help="net used by BOTH arms")
+    p.add_argument("--pool", nargs="+", required=True, help="NN opponent seats")
+    p.add_argument("--a-rollout-opp", default="firstfelix",
+                   choices=["chicken", "firstfelix", "nn"])
+    p.add_argument("--b-rollout-opp", default="nn",
+                   choices=["chicken", "firstfelix", "nn"])
+    p.add_argument("--a-nn-model", required=True)
+    p.add_argument("--b-nn-model", required=True)
+    p.add_argument("--a-belief", default=None, help="belief ONNX for arm A (None=uniform)")
+    p.add_argument("--b-belief", default=None, help="belief ONNX for arm B (None=uniform)")
+    p.add_argument("--n-worlds", type=int, default=64)
+    p.add_argument("--top-k", type=int, default=6)
+    p.add_argument("--n-games", type=int, default=400)
+    p.add_argument("--z-threshold", type=float, default=1.5)
+    p.add_argument("--min-gain", type=float, default=0.25)
+    p.add_argument("--n-workers", type=int, default=4)
+    p.add_argument("--rollout-threads", type=int, default=3)
+    p.add_argument("--seed-offset", type=int, default=50_000_000)
+    args = p.parse_args()
+
+    seeds = list(range(args.seed_offset, args.seed_offset + args.n_games))
+    results = []
+    t0 = time.time()
+    def _bel(x):
+        return Path(x).stem if x else "uniform"
+    print(f"A=[ropp={args.a_rollout_opp}, nn={Path(args.a_nn_model).stem}, "
+          f"belief={_bel(args.a_belief)}]  "
+          f"B=[ropp={args.b_rollout_opp}, nn={Path(args.b_nn_model).stem}, "
+          f"belief={_bel(args.b_belief)}]  "
+          f"mixed tables, pool={len(args.pool)} nets, n={args.n_games}")
+    sys.stdout.flush()
+    with ProcessPoolExecutor(
+        max_workers=args.n_workers, initializer=_worker_init,
+        initargs=(args.jar, args.checkpoint, args.a_rollout_opp,
+                  args.b_rollout_opp, args.a_nn_model, args.b_nn_model,
+                  args.a_belief, args.b_belief,
+                  tuple(args.pool), args.n_worlds, args.top_k,
+                  args.z_threshold, args.min_gain, args.rollout_threads),
+    ) as pool_exec:
+        for res in pool_exec.map(_play_seed, seeds, chunksize=2):
+            results.append(res)
+            n = len(results)
+            if n % 25 == 0:
+                a = np.array([r["A"] for r in results])
+                b = np.array([r["B"] for r in results])
+                d = b - a
+                print(f"[{n}/{args.n_games}] {time.time()-t0:.0f}s  "
+                      f"A={a.mean():+.2f} B={b.mean():+.2f} "
+                      f"delta={d.mean():+.2f}±{d.std()/np.sqrt(n):.2f}")
+                sys.stdout.flush()
+
+    a = np.array([r["A"] for r in results]); b = np.array([r["B"] for r in results])
+    d = b - a
+    print(f"\narm A: {a.mean():+.3f}/game  win {np.mean(a>0):.1%}")
+    print(f"arm B: {b.mean():+.3f}/game  win {np.mean(b>0):.1%}")
+    print(f"paired delta (B-A): {d.mean():+.3f} ± {d.std()/np.sqrt(len(d)):.3f}  "
+          f"(n={len(d)}, {d.mean()/(d.std()/np.sqrt(len(d))):+.2f} sigma)")
+
+
+if __name__ == "__main__":
+    main()

--- a/rl/exit_datagen3.py
+++ b/rl/exit_datagen3.py
@@ -135,6 +135,7 @@ def main():
                 out["discard_cands"] = np.array([s["cands"] for s in samples], dtype=np.int64)
                 out["discard_mean_d"] = np.array([s["mean_d"] for s in samples], dtype=np.float32)
                 out["discard_se_d"] = np.array([s["se_d"] for s in samples], dtype=np.float32)
+                out["discard_balance"] = np.array([s["balance"] for s in samples], dtype=np.float32)
         np.savez_compressed(
             save_dir / f"shard_w{args.worker_id:02d}_{shard_idx:04d}.npz", **out)
         buf = defaultdict(list)
@@ -153,6 +154,7 @@ def main():
             sample["cands"] = pad(ainfo.get("candidates", [action]), -1)
             sample["mean_d"] = pad(ainfo.get("mean_diffs", [0.0]), 0.0)
             sample["se_d"] = pad(ainfo.get("se_diffs", [0.0]), 1e9)
+            sample["balance"] = 0.0  # value target — filled with final game reward below
         buf[decision].append(sample)
         return int(action)
 
@@ -188,6 +190,7 @@ def main():
     for gi, seed in enumerate(my_seeds):
         ttype = table_for(seed)
         type_counts[ttype] += 1
+        d0 = len(buf["discard"])  # value-corpus: mark where this game's discard states start
         if ttype == "mixed":
             r = play_mixed(seed)
         elif ttype == "ff":
@@ -196,6 +199,10 @@ def main():
             r = play_heuristic(ch_env, seed)
         if r is not None:
             game_rewards.append(r)
+            for s in buf["discard"][d0:]:  # tag every discard state with the final game balance
+                s["balance"] = float(r)
+        else:
+            del buf["discard"][d0:]  # drop a failed game's untagged discard states
 
         if (gi + 1) % args.games_per_shard == 0:
             flush()

--- a/rl/value_train.py
+++ b/rl/value_train.py
@@ -61,8 +61,9 @@ def main():
     tr_obs, tr_val = obs[n_val:], val[n_val:]
     va_obs, va_val = obs[:n_val], val[:n_val]
 
+    dev = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     agent = MahjongAgent.load(args.student, device="cpu")
-    net = agent.net
+    net = agent.net.to(dev)
     net.train()
     if args.unfreeze:
         # Ceiling probe: train the whole value path (may disturb the policy — do
@@ -78,8 +79,8 @@ def main():
             prm.requires_grad = True
         opt = torch.optim.Adam(net.value_head.parameters(), lr=args.lr)
 
-    tr_obs_t = torch.tensor(tr_obs); tr_val_t = torch.tensor(tr_val)
-    va_obs_t = torch.tensor(va_obs); va_val_t = torch.tensor(va_val)
+    tr_obs_t = torch.tensor(tr_obs).to(dev); tr_val_t = torch.tensor(tr_val).to(dev)
+    va_obs_t = torch.tensor(va_obs).to(dev); va_val_t = torch.tensor(va_val).to(dev)
 
     def val_pred(obs_t):
         preds = []
@@ -104,7 +105,7 @@ def main():
         # Held-out metrics.
         vp = val_pred(va_obs_t)
         va_mse = float(((vp - va_val_t) ** 2).mean())
-        corr = float(np.corrcoef(vp.numpy(), va_val.astype(np.float64))[0, 1])
+        corr = float(np.corrcoef(vp.cpu().numpy(), va_val.astype(np.float64))[0, 1])
         print(f"epoch {epoch+1:2d}: train_mse={tot/n:7.3f}  "
               f"val_mse={va_mse:7.3f}  (baseline {baseline_mse:7.3f})  "
               f"corr={corr:.3f}", flush=True)
@@ -112,6 +113,7 @@ def main():
     r2 = 1.0 - va_mse / baseline_mse
     print(f"\nACCURACY GATE: val corr={corr:.3f}  R^2={r2:.3f}  "
           f"(val_mse {va_mse:.2f} vs baseline {baseline_mse:.2f})")
+    net.to("cpu")
     agent.save(args.out)
     print(f"saved -> {args.out}")
 

--- a/src/main/scala-2.12/io/fele/app/mahjong/rl/BeliefDataGen.scala
+++ b/src/main/scala-2.12/io/fele/app/mahjong/rl/BeliefDataGen.scala
@@ -43,6 +43,15 @@ object BeliefDataGen extends App {
   private val oppType = System.getProperty("rl.beliefopp", "firstfelix").toLowerCase
   private val seed0   = Integer.getInteger("rl.beliefseed", 0).toLong
 
+  // NN opponent policy (loaded lazily from -Drl.beliefnnmodel=<path.onnx>), so the
+  // belief model can be trained against the hand-discard patterns of a strong net
+  // rather than FirstFelix — the regime the league teacher actually faces.
+  private lazy val nnService: OnnxPolicyService = {
+    val path = System.getProperty("rl.beliefnnmodel")
+    require(path != null, "beliefopp 'nn' needs -Drl.beliefnnmodel=<path.onnx>")
+    new OnnxPolicyService(path)
+  }
+
   private def counts(tiles: Seq[Tile]): Array[Int] = {
     val a = Array.fill(34)(0)
     tiles.foreach(t => a(t.toTileValue) += 1)
@@ -93,6 +102,7 @@ object BeliefDataGen extends App {
 
   private def makePlayer(id: Int, tiles: List[Tile]): Player = oppType match {
     case "chicken" => new Chicken(id, tiles)
+    case "nn"      => new NNPlayer(id, tiles, List.empty[TileGroup], nnService)
     case _         => new FirstFelix(id, tiles, 5)
   }
 


### PR DESCRIPTION
Preserves the tooling and record from the 2026-07 lever re-audit.

## What this is
Re-audited every shelved RL quality lever for a FirstFelix-benchmark confound (FF is too weak to punish deal-ins, and FF-rollouts are oracle-correct, so defensive/opponent-modeling levers can't show value vs FF). Re-tested them off FF on self-play mixed tables.

## Result: ceiling confirmed
The confound was real, but the levers still don't convert once tested where opponents punish mistakes:
- Belief determinization (#17): NN-belief validated (recall@6 51% vs 27.5%) but A/B −1.65±1.44
- Rollout-realism (#25): null on mixed tables (−0.45±2.55)
- Data-scale/league round: new net ties D on anchors (head-to-head was a matchup artifact)
- Value-leaf (#20): value net R² 0.58→0.79 but RMS ~\$12.5, far from the ≪\$2 bar
- top_k pruning (+0.68±1.75) and self-tail (+0.27±4.06): null

Champion unchanged (net D). Search/data levers exhausted.

## Reusable tooling added
- `eval_teacher_mixed.py` — paired mixed-table teacher A/B (per-arm rollout_opp/nn_model/belief)
- `BeliefDataGen.scala` — `-Drl.beliefopp=nn` NN-opponent belief datagen
- `exit_datagen3.py` — value-corpus logging (`discard_balance`)
- `value_train.py` — GPU support
- `TRAINING_HISTORY.md` — full write-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)