### PR TITLE
rl: exploitability probes + teacher-gap — ceiling confirmed by measurement

### DIFF
--- a/rl/eval_teacher_gap.py
+++ b/rl/eval_teacher_gap.py
@@ -1,0 +1,119 @@
+"""
+eval_teacher_gap.py — measure the TRUE exploit gap: teacher vs frozen champions.
+
+The freeze-trunk exploit probe showed head-only PPO cannot beat the champion
+(gap ~0). But the project already owns a stronger policy: the TEACHER
+(champion + 64-world CRN search). This measures the teacher's money at seat 0
+against 3 frozen champions on the SAME 400-seed eval block the probe used, so
+the result is directly comparable to the probe's raw-champion baseline
+(+3.670 ± 1.230). teacher_money − baseline = the real, already-reachable
+exploit gap — i.e. the headroom distillation is failing to transfer.
+
+    rl/venv/bin/python rl/eval_teacher_gap.py \
+        --champion rl/checkpoints/best_raw_net.pt \
+        --nn-model rl/checkpoints/student/student48_sp1b.onnx \
+        --n-games 400 --n-workers 4
+"""
+
+import argparse
+import sys
+import time
+from concurrent.futures import ProcessPoolExecutor
+from pathlib import Path
+
+import numpy as np
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+_W = {}
+
+
+def _worker_init(jar, ckpt, nn_model, n_worlds, top_k, z, min_gain, threads):
+    import torch
+    torch.set_num_threads(1)
+    from env import encode_state, get_action_mask  # noqa: F401
+    from model import MahjongAgent
+    from mcts import MCTSRolloutClient, PairedMCTSPolicy
+    from self_play import TrueSelfPlayEnv
+
+    agent = MahjongAgent.load(ckpt, device="cpu")
+    assert agent.net.obs_dim == 759, "expects a v3 net"
+    client = MCTSRolloutClient(jar_path=jar, rollout_opp="firstfelix",
+                               nn_model=nn_model, rollout_threads=threads)
+    _W["teacher"] = PairedMCTSPolicy(
+        net=agent.net, rollout_client=client, n_worlds=n_worlds, top_k=top_k,
+        z_threshold=z, min_gain=min_gain, device="cpu", self_policy="nn")
+    _W["champ"] = agent
+    _W["sp"] = TrueSelfPlayEnv(jar)
+
+
+def _play_seed(seed):
+    from env import encode_state, get_action_mask
+    sp, teacher, champ = _W["sp"], _W["teacher"], _W["champ"]
+    n_sw = n_dec = 0
+    msg = sp.reset(seed=seed)
+    while True:
+        if msg["type"] == "game_over":
+            return float(msg["rewards"]["0"]), n_sw, n_dec
+        seat = int(msg["seat_id"])
+        decision, context = msg["decision"], msg.get("context", {})
+        obs = encode_state(msg["state"], version=3, context=context)
+        mask = get_action_mask(decision, context)
+        if seat == 0:
+            action, ainfo = teacher.get_action(obs, msg["state"], decision, context, mask)
+            if "mean_gain" in ainfo:
+                n_dec += 1
+                n_sw += bool(ainfo.get("switched"))
+        else:
+            action = champ.select_action(obs, decision, mask, deterministic=True)
+        msg = sp.step(decision, int(action))
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--jar", default="target/scala-2.12/mahjong-assembly-0.1.0.jar")
+    p.add_argument("--champion", required=True)
+    p.add_argument("--nn-model", required=True)
+    p.add_argument("--n-worlds", type=int, default=64)
+    p.add_argument("--top-k", type=int, default=6)
+    p.add_argument("--z-threshold", type=float, default=1.5)
+    p.add_argument("--min-gain", type=float, default=0.25)
+    p.add_argument("--n-games", type=int, default=400)
+    p.add_argument("--n-workers", type=int, default=4)
+    p.add_argument("--rollout-threads", type=int, default=3)
+    p.add_argument("--seed-offset", type=int, default=70_000_000,
+                   help="MUST match the exploit-probe eval block for pairing")
+    p.add_argument("--baseline", type=float, default=3.670,
+                   help="raw-champion money on the same block (exploit probe)")
+    args = p.parse_args()
+
+    seeds = list(range(args.seed_offset, args.seed_offset + args.n_games))
+    money, sw, dec = [], 0, 0
+    t0 = time.time()
+    print(f"teacher = {args.champion} + {args.n_worlds}w/top{args.top_k} search, "
+          f"table = 3x frozen champion, n={args.n_games}, seeds@{args.seed_offset}", flush=True)
+    with ProcessPoolExecutor(
+        max_workers=args.n_workers, initializer=_worker_init,
+        initargs=(args.jar, args.champion, args.nn_model, args.n_worlds,
+                  args.top_k, args.z_threshold, args.min_gain, args.rollout_threads),
+    ) as pool:
+        for r, s, d in pool.map(_play_seed, seeds, chunksize=2):
+            money.append(r); sw += s; dec += d
+            n = len(money)
+            if n % 25 == 0:
+                m = np.array(money)
+                print(f"[{n}/{args.n_games}] {time.time()-t0:.0f}s  "
+                      f"teacher={m.mean():+.2f}±{m.std()/np.sqrt(n):.2f}  "
+                      f"gap={m.mean()-args.baseline:+.2f}  "
+                      f"switch={sw}/{dec} ({sw/max(1,dec):.1%})", flush=True)
+
+    m = np.array(money)
+    se = m.std() / np.sqrt(len(m))
+    print(f"\nTEACHER on frozen-champion table: {m.mean():+.3f} ± {se:.3f}/game  "
+          f"win {np.mean(m>0):.1%}  switch {sw}/{dec} ({sw/max(1,dec):.1%})")
+    print(f"TRUE EXPLOIT GAP (teacher − raw champion {args.baseline:+.3f}): "
+          f"{m.mean()-args.baseline:+.3f} ± {se:.3f}/game")
+
+
+if __name__ == "__main__":
+    main()

--- a/rl/exit_distill_soft.py
+++ b/rl/exit_distill_soft.py
@@ -77,6 +77,9 @@ def main():
     p.add_argument("--batch-size", type=int,   default=512)
     p.add_argument("--tau-floor",  type=float, default=1.0)
     p.add_argument("--tau-scale",  type=float, default=1.0)
+    p.add_argument("--switched-weight", type=float, default=1.0,
+                   help="loss weight for search-SWITCHED discard samples (the ~14% "
+                        "of data carrying the teacher's edge; 1.0 = original recipe)")
     p.add_argument("--device",     default="cuda")
     args = p.parse_args()
 
@@ -143,7 +146,14 @@ def main():
                     # padded candidates: tgt=0 but logp=-inf → mask to avoid 0*inf=nan
                     contrib = torch.where(tgt_b > 0, tgt_b * logp_c,
                                           torch.zeros_like(logp_c))
-                    loss = -contrib.sum(dim=1).mean()
+                    per_sample = -contrib.sum(dim=1)                 # (B,)
+                    if args.switched_weight != 1.0:
+                        w = torch.where(sw_b,
+                                        torch.full_like(per_sample, args.switched_weight),
+                                        torch.ones_like(per_sample))
+                        loss = (per_sample * w).sum() / w.sum()
+                    else:
+                        loss = per_sample.mean()
                     preds = logits.argmax(dim=-1)
                     agree_nn += (preds == act_b).sum().item()
                     agree_sw += (preds[sw_b] == act_b[sw_b]).sum().item()

--- a/rl/exploit_probe.py
+++ b/rl/exploit_probe.py
@@ -1,0 +1,237 @@
+"""
+exploit_probe.py — approximate best-response / exploitability probe.
+
+Question this answers: is the champion actually strong, or just strong vs
+FirstFelix? We freeze the champion at seats 1-3 and train a fresh exploiter at
+seat 0 (PPO) whose ONLY goal is to beat those three frozen champions. The
+exploiter is warm-started FROM the champion, so it begins at parity (a net
+playing 3 copies of itself in a zero-sum 4-player game averages ~0/game) and
+RL pushes it to find the exploit delta.
+
+Interpretation:
+  * exploiter climbs to +X/game  → the champion leaves ~$X on the table; a
+    strictly better policy is reachable → real headroom to improve.
+  * exploiter stays near the baseline → the champion is robust to a best
+    response from its own policy neighbourhood → "ceiling" is confirmed with
+    evidence, not benchmark-saturation ambiguity.
+
+We first measure a BASELINE (untrained exploiter = champion, seat 0 vs 3 frozen
+champions) to fix the zero point (controls for any seat/dealer positional bias),
+then train and report seat-0 money vs that baseline.
+
+Usage
+─────
+    rl/venv/bin/python rl/exploit_probe.py \
+        --champion rl/checkpoints/best_raw_net.pt \
+        --total-games 40000 --games-per-update 64 --device cuda
+"""
+
+import argparse
+import collections
+import sys
+import time
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import numpy as np
+import torch
+import torch.nn as nn
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from env import encode_state, get_action_mask, DECISION_SPACES
+from model import MahjongAgent
+from self_play import TrueSelfPlayEnv, Transition
+
+V = 3  # champion is a v3 (759-dim) net
+
+
+def _play_game(sp_env, exploiter, champion, device, seed):
+    """Seat 0 = exploiter (stochastic, records transitions); seats 1-3 = frozen
+    champion (deterministic argmax). Returns (seat0_transitions, seat0_reward)."""
+    msg = sp_env.reset(seed=seed)
+    seat0: List[Transition] = []
+    while True:
+        if msg["type"] == "game_over":
+            return seat0, float(msg["rewards"]["0"])
+        seat_id  = int(msg["seat_id"])
+        decision = msg["decision"]
+        context  = msg.get("context", {})
+        obs  = encode_state(msg["state"], version=V, context=context)
+        mask = get_action_mask(decision, context)
+        if seat_id == 0:
+            obs_t = torch.tensor(obs, dtype=torch.float32, device=device).unsqueeze(0)
+            mask_t = (torch.tensor(mask, dtype=torch.bool, device=device).unsqueeze(0)
+                      if mask is not None else None)
+            with torch.no_grad():
+                a_t, lp_t, v_t = exploiter.net.act(obs_t, decision, mask_t)
+            action = int(a_t.item())
+            seat0.append(Transition(obs=obs, decision=decision, action=action,
+                                    log_prob=float(lp_t.item()), value=float(v_t.item()),
+                                    reward=0.0, done=False, action_mask=mask))
+        else:
+            action = champion.select_action(obs, decision, mask, deterministic=True)
+        msg = sp_env.step(decision, int(action))
+
+
+def _eval_deterministic(sp_env, seat0_agent, champion, device, n, seed0):
+    """DETERMINISTIC apples-to-apples: seat 0 = seat0_agent (argmax) vs 3 frozen
+    champions (argmax). With seat0_agent=champion this is the symmetric zero
+    point; with seat0_agent=exploiter it is the true exploitability. Both sides
+    play the same way (argmax), so no stochastic-sampling handicap."""
+    money = []
+    for g in range(n):
+        msg = sp_env.reset(seed=seed0 + g)
+        while msg["type"] != "game_over":
+            seat_id  = int(msg["seat_id"])
+            decision = msg["decision"]
+            context  = msg.get("context", {})
+            obs  = encode_state(msg["state"], version=V, context=context)
+            mask = get_action_mask(decision, context)
+            agent = seat0_agent if seat_id == 0 else champion
+            action = agent.select_action(obs, decision, mask, deterministic=True)
+            msg = sp_env.step(decision, int(action))
+        money.append(float(msg["rewards"]["0"]))
+    return float(np.mean(money)), float(np.std(money) / np.sqrt(len(money)))
+
+
+def _ppo_update(net, opt, games, device, gamma, gae_lambda, clip_eps,
+                value_coef, entropy_coef, max_grad_norm, n_epochs, batch_size):
+    by_dec: Dict[str, List[dict]] = collections.defaultdict(list)
+    for transitions, final_reward in games:
+        if not transitions:
+            continue
+        n = len(transitions)
+        returns = np.zeros(n, dtype=np.float32)
+        returns[-1] = final_reward
+        for i in range(n - 2, -1, -1):
+            returns[i] = gamma * returns[i + 1]
+        values = np.array([t.value for t in transitions], dtype=np.float32)
+        next_v = np.append(values[1:], final_reward)
+        deltas = returns - values + gamma * next_v
+        adv = np.zeros(n, dtype=np.float32); a = 0.0
+        for i in range(n - 1, -1, -1):
+            a = deltas[i] + gamma * gae_lambda * a
+            adv[i] = a
+        for i, t in enumerate(transitions):
+            n_act = DECISION_SPACES[t.decision]
+            mask = t.action_mask if t.action_mask is not None else np.ones(n_act, dtype=bool)
+            by_dec[t.decision].append({"obs": t.obs, "action": t.action,
+                                       "old_log_prob": t.log_prob, "return_": float(returns[i]),
+                                       "advantage": float(adv[i]), "mask": mask})
+    stats = collections.defaultdict(list)
+    for _ in range(n_epochs):
+        for dec, samples in by_dec.items():
+            advs = np.array([s["advantage"] for s in samples], dtype=np.float32)
+            advs = (advs - advs.mean()) / (advs.std() + 1e-8)
+            obs_a = np.stack([s["obs"] for s in samples])
+            act_a = np.array([s["action"] for s in samples], dtype=np.int64)
+            lp_a  = np.array([s["old_log_prob"] for s in samples], dtype=np.float32)
+            ret_a = np.array([s["return_"] for s in samples], dtype=np.float32)
+            msk_a = np.stack([s["mask"] for s in samples])
+            idx = np.random.permutation(len(samples))
+            for st in range(0, len(idx), batch_size):
+                b = idx[st: st + batch_size]
+                obs_t = torch.tensor(obs_a[b], dtype=torch.float32, device=device)
+                act_t = torch.tensor(act_a[b], dtype=torch.long, device=device)
+                lp_t  = torch.tensor(lp_a[b], dtype=torch.float32, device=device)
+                ret_t = torch.tensor(ret_a[b], dtype=torch.float32, device=device)
+                adv_t = torch.tensor(advs[b], dtype=torch.float32, device=device)
+                msk_t = torch.tensor(msk_a[b], dtype=torch.bool, device=device)
+                log_prob, entropy, value = net.evaluate_actions(obs_t, dec, act_t, msk_t)
+                ratio = torch.exp(log_prob - lp_t)
+                s1 = ratio * adv_t
+                s2 = torch.clamp(ratio, 1 - clip_eps, 1 + clip_eps) * adv_t
+                p_loss = -torch.min(s1, s2).mean()
+                v_loss = nn.functional.mse_loss(value, ret_t)
+                e_loss = -entropy.mean()
+                loss = p_loss + value_coef * v_loss + entropy_coef * e_loss
+                opt.zero_grad(); loss.backward()
+                nn.utils.clip_grad_norm_(net.parameters(), max_grad_norm)
+                opt.step()
+                stats["policy_loss"].append(p_loss.item())
+                stats["entropy"].append(-e_loss.item())
+    return {k: float(np.mean(v)) for k, v in stats.items()}
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--jar", default="target/scala-2.12/mahjong-assembly-0.1.0.jar")
+    p.add_argument("--champion", required=True)
+    p.add_argument("--total-games", type=int, default=40000)
+    p.add_argument("--games-per-update", type=int, default=64)
+    p.add_argument("--eval-games", type=int, default=400,
+                   help="deterministic eval block (baseline + each exploit eval)")
+    p.add_argument("--eval-every", type=int, default=5, help="eval every N updates")
+    p.add_argument("--freeze-trunk", action="store_true",
+                   help="freeze stem+blocks (champion features), train only decision heads — "
+                        "can't catastrophically forget, so a stable best-response probe")
+    p.add_argument("--lr", type=float, default=3e-4)
+    p.add_argument("--entropy-coef", type=float, default=0.01)
+    p.add_argument("--device", default="cuda")
+    p.add_argument("--seed-offset", type=int, default=70_000_000)
+    p.add_argument("--out", default="rl/checkpoints/exploiter.pt")
+    args = p.parse_args()
+
+    dev = torch.device(args.device if torch.cuda.is_available() else "cpu")
+    champion = MahjongAgent.load(args.champion, device=str(dev))
+    exploiter = MahjongAgent.load(args.champion, device=str(dev))  # warm-start = parity
+    assert champion.net.obs_dim == 759, "expects a v3 net"
+    if args.freeze_trunk:
+        n_frozen = n_train = 0
+        for name, prm in exploiter.net.named_parameters():
+            if name.startswith("stem.") or name.startswith("blocks."):
+                prm.requires_grad = False; n_frozen += prm.numel()
+            else:
+                n_train += prm.numel()
+        print(f"FREEZE-TRUNK: frozen {n_frozen:,} trunk params, training {n_train:,} head params",
+              flush=True)
+    train_params = [p for p in exploiter.net.parameters() if p.requires_grad]
+    opt = torch.optim.Adam(train_params, lr=args.lr, eps=1e-5)
+    sp_env = TrueSelfPlayEnv(args.jar)
+
+    print(f"champion={args.champion}  device={dev}  lr={args.lr}  ent={args.entropy_coef}", flush=True)
+    # Fixed eval seed block, reused for baseline + every exploiter eval (paired).
+    eval_seed0 = args.seed_offset
+    base_mean, base_se = _eval_deterministic(sp_env, champion, champion, dev,
+                                             args.eval_games, eval_seed0)
+    print(f"BASELINE (champion argmax seat0 vs 3 frozen champions, n={args.eval_games}): "
+          f"{base_mean:+.3f} ± {base_se:.3f}/game  (symmetric zero point)", flush=True)
+    # t=0 sanity: warm-started exploiter (untrained) must start at gap ~0.
+    e0_mean, _ = _eval_deterministic(sp_env, exploiter, champion, dev, args.eval_games, eval_seed0)
+    print(f"t=0 exploiter (untrained warm-start) eval={e0_mean:+.3f} → gap {e0_mean-base_mean:+.3f} "
+          f"(must be ~0; if it collapses below this during training, LR too high)", flush=True)
+
+    seed = args.seed_offset + 1_000_000  # train seeds disjoint from eval block
+    played = 0; upd = 0; t0 = time.time(); best_gap = 0.0
+    while played < args.total_games:
+        games = []
+        for _ in range(args.games_per_update):
+            tr, r = _play_game(sp_env, exploiter, champion, dev, seed)
+            games.append((tr, r)); seed += 1; played += 1
+        st = _ppo_update(exploiter.net, opt, games, dev, gamma=0.99, gae_lambda=0.95,
+                         clip_eps=0.2, value_coef=0.5, entropy_coef=args.entropy_coef,
+                         max_grad_norm=0.5, n_epochs=4, batch_size=512)
+        upd += 1
+        train_m = float(np.mean([r for _, r in games]))
+        if upd % args.eval_every == 0:
+            # Deterministic exploitability eval on the FIXED eval block (paired vs baseline)
+            ev_mean, ev_se = _eval_deterministic(sp_env, exploiter, champion, dev,
+                                                 args.eval_games, eval_seed0)
+            gap = ev_mean - base_mean
+            if gap > best_gap:
+                best_gap = gap; exploiter.save(args.out)
+            print(f"[{played}/{args.total_games}] {time.time()-t0:.0f}s  "
+                  f"train_money={train_m:+.2f}  EVAL(det)={ev_mean:+.2f}±{ev_se:.2f}  "
+                  f"exploit_gap={gap:+.2f}  ent={st.get('entropy',0):.3f}", flush=True)
+        else:
+            print(f"[{played}/{args.total_games}] {time.time()-t0:.0f}s  "
+                  f"train_money={train_m:+.2f}  ent={st.get('entropy',0):.3f}", flush=True)
+
+    print(f"\nEXPLOITABILITY: best deterministic exploit gap {best_gap:+.3f}/game "
+          f"(eval {base_mean+best_gap:+.2f} vs baseline {base_mean:+.2f}, n={args.eval_games})", flush=True)
+    print(f"saved best exploiter → {args.out}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Final tranche of the "can the model still be improved?" investigation. Three new instruments, one coherent negative:

| Instrument | Result |
|---|---|
| Best-response RL vs frozen champion (`exploit_probe.py`, freeze-trunk) | flat at baseline, best gap +0.50 = noise |
| Teacher (champion+search) vs frozen-champion table (`eval_teacher_gap.py`) | **true exploit gap −0.98 ± 1.27 ≈ 0** |
| Switched-sample upweighted distillation (`--switched-weight`) | monotonically worse (FF anchor 2.85 → 2.29 → 0.82) |

Key insight: the teacher's historical +1/game edge over the raw net exists only against FirstFelix tables — its rollouts model opponents as FF, an oracle there and a wrong model against strong nets. Against a champion table the edge evaporates, so there is no transferable headroom, which is why every distillation round plateaued and why upweighting the "teacher's corrections" actively hurts.

Champion D stands. Improvement paths from here require external signal (human game data via the web app) or a search with a correct strong-opponent model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A8JbBsdzSQNNAB4xNbFoYC