### PR TITLE
server: game-record persistence — per-game event streams in Postgres (#30 step 1)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -57,6 +57,8 @@ lazy val server = (project in file("server"))
       "ch.qos.logback"  %  "logback-classic"     % "1.4.14",
       "org.scalatest"   %% "scalatest"           % "3.2.18" % Test
     ),
+    // Suites share one Postgres and race on CREATE TABLE IF NOT EXISTS otherwise
+    Test / parallelExecution := false,
     assembly / mainClass := Some("io.fele.mahjong.server.Main"),
     assembly / assemblyMergeStrategy := {
       case PathList("META-INF", "io.netty.versions.properties") => MergeStrategy.first

--- a/server/src/main/scala/io/fele/mahjong/server/GameRecordRepo.scala
+++ b/server/src/main/scala/io/fele/mahjong/server/GameRecordRepo.scala
@@ -1,0 +1,212 @@
+package io.fele.mahjong.server
+
+import cats.effect.IO
+import cats.syntax.all._
+import doobie._
+import doobie.implicits._
+import doobie.postgres.implicits._
+import io.circe.{Decoder, Encoder}
+import io.circe.generic.semiauto._
+import io.circe.parser.decode
+import io.circe.syntax._
+import io.fele.app.mahjong.WinnersInfo
+import io.fele.mahjong.server.Models._
+
+import java.time.Instant
+
+/** Final result of a recorded game. `drawn` means the wall was exhausted with
+  * no winner. Seat indices coincide with engine player ids. */
+case class OutcomeWinner(seat: Int, score: Int)
+object OutcomeWinner {
+  implicit val enc: Encoder[OutcomeWinner] = deriveEncoder
+  implicit val dec: Decoder[OutcomeWinner] = deriveDecoder
+}
+
+case class GameOutcome(
+  drawn:       Boolean,
+  isSelfWin:   Boolean,
+  winningTile: Option[String],
+  loserSeat:   Option[Int],
+  winners:     List[OutcomeWinner]
+)
+object GameOutcome {
+  implicit val enc: Encoder[GameOutcome] = deriveEncoder
+  implicit val dec: Decoder[GameOutcome] = deriveDecoder
+
+  def from(wi: Option[WinnersInfo]): GameOutcome = wi match {
+    case None => GameOutcome(drawn = true, isSelfWin = false, None, None, Nil)
+    case Some(w) => GameOutcome(
+      drawn       = false,
+      isSelfWin   = w.isSelfWin,
+      winningTile = Some(Models.tileToWire(w.winningTile)),
+      loserSeat   = w.loserId,
+      winners     = w.winners.toList.sortBy(_.id).map(x => OutcomeWinner(x.id, x.score))
+    )
+  }
+}
+
+object GameRecordStatus {
+  val InProgress = "in_progress"
+  val Finished   = "finished"
+  val Aborted    = "aborted"
+}
+
+case class GameRecordRow(
+  id:         String,
+  roomId:     RoomId,
+  seats:      List[Seat],
+  seed:       Option[Long],
+  wall:       List[String],          // 136 tiles in draw order; slice(13*i, 13*(i+1)) = seat i's deal
+  status:     String,
+  outcome:    Option[GameOutcome],
+  startedAt:  Instant,
+  finishedAt: Option[Instant]
+)
+
+case class GameEventRow(
+  gameId:       String,
+  seq:          Int,
+  eventType:    String,               // start | resume | draw | discard | kong | pong | chow | end
+  seat:         Option[Int],          // acting seat (kong/pong/chow: the claiming seat)
+  sourceSeat:   Option[Int],          // seat whose discard was claimed (== seat for self-kong)
+  tile:         Option[String],
+  chowPosition: Option[String],       // LEFT | MIDDLE | RIGHT
+  ts:           Instant
+)
+
+/** Postgres persistence of complete per-game event streams (issue #30).
+  *
+  * Events, not observations: the wall + seat kinds + the ordered event stream
+  * are sufficient for the engine to deterministically replay a game and
+  * reconstruct every hidden hand at every decision point, at any obs version.
+  */
+class GameRecordRepo(xa: Transactor[IO]) {
+
+  def init: IO[Unit] = {
+    val games = sql"""
+      CREATE TABLE IF NOT EXISTS game_records (
+        id           TEXT PRIMARY KEY,
+        room_id      TEXT NOT NULL,
+        seats_json   TEXT NOT NULL,
+        seed         BIGINT,
+        wall_json    TEXT NOT NULL,
+        status       TEXT NOT NULL,
+        outcome_json TEXT,
+        started_at   TIMESTAMPTZ NOT NULL,
+        finished_at  TIMESTAMPTZ
+      )
+    """.update.run
+    val gamesIdx = sql"""
+      CREATE INDEX IF NOT EXISTS game_records_room_idx ON game_records (room_id)
+    """.update.run
+    val events = sql"""
+      CREATE TABLE IF NOT EXISTS game_events (
+        game_id       TEXT NOT NULL REFERENCES game_records(id) ON DELETE CASCADE,
+        seq           INT NOT NULL,
+        event_type    TEXT NOT NULL,
+        seat          INT,
+        source_seat   INT,
+        tile          TEXT,
+        chow_position TEXT,
+        ts            TIMESTAMPTZ NOT NULL,
+        PRIMARY KEY (game_id, seq)
+      )
+    """.update.run
+    (games *> gamesIdx *> events).transact(xa).void
+  }
+
+  def insertGame(
+    id:        String,
+    roomId:    RoomId,
+    seats:     List[Seat],
+    seed:      Option[Long],
+    wall:      List[String],
+    startedAt: Instant
+  ): IO[Unit] = {
+    val seatsJson = seats.asJson.noSpaces
+    val wallJson  = wall.asJson.noSpaces
+    val status    = GameRecordStatus.InProgress
+    sql"""
+      INSERT INTO game_records (id, room_id, seats_json, seed, wall_json, status, started_at)
+      VALUES ($id, $roomId, $seatsJson, $seed, $wallJson, $status, $startedAt)
+    """.update.run.transact(xa).void
+  }
+
+  def insertEvent(e: GameEventRow): IO[Unit] =
+    sql"""
+      INSERT INTO game_events (game_id, seq, event_type, seat, source_seat, tile, chow_position, ts)
+      VALUES (${e.gameId}, ${e.seq}, ${e.eventType}, ${e.seat}, ${e.sourceSeat}, ${e.tile}, ${e.chowPosition}, ${e.ts})
+    """.update.run.transact(xa).void
+
+  def finishGame(id: String, outcome: GameOutcome, finishedAt: Instant): IO[Unit] = {
+    val outcomeJson = outcome.asJson.noSpaces
+    val status      = GameRecordStatus.Finished
+    sql"""
+      UPDATE game_records SET status = $status, outcome_json = $outcomeJson, finished_at = $finishedAt
+      WHERE id = $id
+    """.update.run.transact(xa).void
+  }
+
+  def abortGame(id: String, finishedAt: Instant): IO[Unit] = {
+    val status = GameRecordStatus.Aborted
+    sql"""
+      UPDATE game_records SET status = $status, finished_at = $finishedAt
+      WHERE id = $id AND status = ${GameRecordStatus.InProgress}
+    """.update.run.transact(xa).void
+  }
+
+  /** Mark any games left in_progress by a previous process as aborted (runners
+    * are not restored across restarts). Returns the number of rows touched. */
+  def abortStale: IO[Int] = {
+    val aborted = GameRecordStatus.Aborted
+    sql"""
+      UPDATE game_records SET status = $aborted, finished_at = now()
+      WHERE status = ${GameRecordStatus.InProgress}
+    """.update.run.transact(xa)
+  }
+
+  def getGame(id: String): IO[Option[GameRecordRow]] =
+    sql"""
+      SELECT id, room_id, seats_json, seed, wall_json, status, outcome_json, started_at, finished_at
+      FROM game_records WHERE id = $id
+    """.query[(String, String, String, Option[Long], String, String, Option[String], Instant, Option[Instant])]
+      .option
+      .transact(xa)
+      .map(_.flatMap(rowToGame))
+
+  def listGames(roomId: Option[RoomId], limit: Int = 200): IO[List[GameRecordRow]] = {
+    val base =
+      fr"""SELECT id, room_id, seats_json, seed, wall_json, status, outcome_json, started_at, finished_at
+           FROM game_records""" ++
+        roomId.fold(Fragment.empty)(r => fr"WHERE room_id = $r") ++
+        fr"ORDER BY started_at DESC LIMIT $limit"
+    base.query[(String, String, String, Option[Long], String, String, Option[String], Instant, Option[Instant])]
+      .to[List]
+      .transact(xa)
+      .map(_.flatMap(rowToGame))
+  }
+
+  def eventsFor(gameId: String): IO[List[GameEventRow]] =
+    sql"""
+      SELECT game_id, seq, event_type, seat, source_seat, tile, chow_position, ts
+      FROM game_events WHERE game_id = $gameId ORDER BY seq
+    """.query[GameEventRow].to[List].transact(xa)
+
+  /** Deletes the game row; events cascade. */
+  def deleteGame(id: String): IO[Unit] =
+    sql"""DELETE FROM game_records WHERE id = $id""".update.run.transact(xa).void
+
+  private def rowToGame(
+    row: (String, String, String, Option[Long], String, String, Option[String], Instant, Option[Instant])
+  ): Option[GameRecordRow] = {
+    val (id, roomId, seatsJson, seed, wallJson, status, outcomeJson, startedAt, finishedAt) = row
+    for {
+      seats   <- decode[List[Seat]](seatsJson).toOption
+      wall    <- decode[List[String]](wallJson).toOption
+      outcome <- outcomeJson match {
+                   case None    => Some(None)
+                   case Some(j) => decode[GameOutcome](j).toOption.map(Some(_))
+                 }
+    } yield GameRecordRow(id, roomId, seats, seed, wall, status, outcome, startedAt, finishedAt)
+  }
+}

--- a/server/src/main/scala/io/fele/mahjong/server/GameRecorder.scala
+++ b/server/src/main/scala/io/fele/mahjong/server/GameRecorder.scala
@@ -1,0 +1,93 @@
+package io.fele.mahjong.server
+
+import cats.effect.IO
+import cats.effect.std.Dispatcher
+import io.fele.app.mahjong._
+import io.fele.mahjong.server.Models._
+
+import java.time.Instant
+import java.util.UUID
+
+/** Persists one game's complete event stream via [[GameRecordRepo]].
+  *
+  * All calls happen on the dedicated game thread (the engine is synchronous),
+  * so writes are ordered and each event is durable the moment the decision is
+  * made — an abandoned game still keeps every decision up to that point.
+  * A DB failure disables recording for the rest of the game instead of
+  * crashing it.
+  */
+class GameRecorder(
+  repo:       GameRecordRepo,
+  dispatcher: Dispatcher[IO],
+  roomId:     RoomId,
+  seats:      List[Seat],
+  seed:       Option[Long],
+  wall:       Seq[Tile]
+) {
+  val gameId: String = UUID.randomUUID().toString
+
+  private var seq = 0
+  private var closed = false
+  @volatile private var enabled = true
+
+  private def run(io: IO[Unit], what: String): Unit =
+    if (enabled) {
+      try dispatcher.unsafeRunSync(io)
+      catch {
+        case t: Throwable =>
+          enabled = false
+          println(s"WARN: game recording disabled for game $gameId ($what failed: ${t.getMessage})")
+      }
+    }
+
+  /** Insert the game row. Must be called before any event is logged. */
+  def begin(): Unit =
+    run(repo.insertGame(gameId, roomId, seats, seed, wall.map(Models.tileToWire).toList, Instant.now()), "insert game")
+
+  private def event(
+    eventType:  String,
+    seat:       Option[Int]    = None,
+    sourceSeat: Option[Int]    = None,
+    tile:       Option[Tile]   = None,
+    chowPos:    Option[String] = None
+  ): Unit = {
+    val row = GameEventRow(gameId, seq, eventType, seat, sourceSeat, tile.map(Models.tileToWire), chowPos, Instant.now())
+    seq += 1
+    run(repo.insertEvent(row), s"insert event $eventType")
+  }
+
+  /** The engine-facing hook; tee it with the snapshot-publishing logger. */
+  val logger: GameLogger = new GameLogger {
+    override def start():  Unit = event("start")
+    override def resume(): Unit = event("resume")
+    override def draw(e: DrawEvent):       Unit = event("draw",    Some(e.playerId), tile = Some(e.tile))
+    override def discard(e: DiscardEvent): Unit = event("discard", Some(e.playerId), tile = Some(e.tile))
+    override def kong(e: KongEvent):       Unit = event("kong",    Some(e.playerId), Some(e.sourcePlayerId), Some(e.tile))
+    override def pong(e: PongEvent):       Unit = event("pong",    Some(e.playerId), Some(e.sourcePlayerId), Some(e.tile))
+    override def chow(e: ChowEvent):       Unit =
+      event("chow", Some(e.playerId), Some(e.sourcePlayerId), Some(e.tile), Some(e.position.toString))
+    override def end(e: EndEvent): Unit = {
+      event("end")
+      closed = true
+      run(repo.finishGame(gameId, GameOutcome.from(e.winnersInfo), Instant.now()), "finish game")
+    }
+  }
+
+  /** Mark the record aborted if the engine died before emitting `end`. */
+  def close(): Unit = if (!closed) {
+    closed = true
+    run(repo.abortGame(gameId, Instant.now()), "abort game")
+  }
+}
+
+/** Forwards every engine callback to both loggers (persistence + live snapshots). */
+class TeeGameLogger(a: GameLogger, b: GameLogger) extends GameLogger {
+  override def start():  Unit = { a.start();  b.start()  }
+  override def resume(): Unit = { a.resume(); b.resume() }
+  override def discard(e: DiscardEvent): Unit = { a.discard(e); b.discard(e) }
+  override def kong(e: KongEvent):       Unit = { a.kong(e);    b.kong(e)    }
+  override def pong(e: PongEvent):       Unit = { a.pong(e);    b.pong(e)    }
+  override def chow(e: ChowEvent):       Unit = { a.chow(e);    b.chow(e)    }
+  override def end(e: EndEvent):         Unit = { a.end(e);     b.end(e)     }
+  override def draw(e: DrawEvent):       Unit = { a.draw(e);    b.draw(e)    }
+}

--- a/server/src/main/scala/io/fele/mahjong/server/GameRunner.scala
+++ b/server/src/main/scala/io/fele/mahjong/server/GameRunner.scala
@@ -25,7 +25,8 @@ class GameRunner private (
   val players:    List[Player],
   val state:      GameState,
   val webPlayers: Map[Int, WebSocketPlayer],
-  val hooks:      GameHooks
+  val hooks:      GameHooks,
+  val recorder:   Option[GameRecorder]
 )(implicit config: Config) {
 
   /** Subscribe to the live event stream. The most recent snapshot and any
@@ -48,7 +49,10 @@ class GameRunner private (
     val t = new Thread(new Runnable {
       override def run(): Unit = {
         try {
-          implicit val gl: GameLogger = hooks.gameLogger(state, seats)
+          recorder.foreach(_.begin())
+          val liveLogger = hooks.gameLogger(state, seats)
+          implicit val gl: GameLogger =
+            recorder.fold(liveLogger)(r => new TeeGameLogger(r.logger, liveLogger))
           val flow: Flow = new FlowImpl(state)
           flow.start()
           // Wall exhausted with no winner → push a final isFinished=true snapshot
@@ -61,6 +65,7 @@ class GameRunner private (
               "message" -> Json.fromString(Option(e.getMessage).getOrElse(e.toString))
             ))
         } finally {
+          recorder.foreach(_.close())
           hooks.markFinished()
         }
       }
@@ -192,12 +197,15 @@ object GameRunner {
     seed:       Option[Long],
     topic:      Topic[IO, Json],
     dispatcher: Dispatcher[IO],
-    onFinished: IO[Unit] = IO.unit
+    onFinished: IO[Unit] = IO.unit,
+    recordRepo: Option[GameRecordRepo] = None
   )(implicit config: Config): GameRunner = {
     require(seats.size == 4, "must have 4 seats")
     require(seats.forall(_.kind != SeatKind.Open), "cannot start with an open seat")
 
     val drawer: TileDrawer = new RandomTileDrawer(seed)
+    // Capture the full wall before dealing: it determines the deal and every draw.
+    val wall: Seq[Tile] = drawer.drawerState.shuffledTiles
     val hands: List[List[Tile]] = (0 until 4).map(_ => drawer.popHand()).toList
 
     val hooks = new GameHooks(roomId, topic, dispatcher, onFinished)
@@ -225,6 +233,8 @@ object GameRunner {
       drawer         = drawer
     )
 
-    new GameRunner(roomId, seats, players, state, webPlayers.toMap, hooks)
+    val recorder = recordRepo.map(r => new GameRecorder(r, dispatcher, roomId, seats, seed, wall))
+
+    new GameRunner(roomId, seats, players, state, webPlayers.toMap, hooks, recorder)
   }
 }

--- a/server/src/main/scala/io/fele/mahjong/server/Main.scala
+++ b/server/src/main/scala/io/fele/mahjong/server/Main.scala
@@ -33,11 +33,19 @@ object Main extends IOApp {
       xa         <- HikariTransactor.newHikariTransactor[IO](driver, dbUrl, dbUser, dbPass, ce)
       dispatcher <- Dispatcher.parallel[IO]
       repo        = new RoomRepo(xa)
+      gameRepo    = new GameRecordRepo(xa)
       _          <- Resource.eval(IO(println(s"Connecting to Postgres at $dbUrl")))
       _          <- Resource.eval(repo.init.handleErrorWith { t =>
                       IO(println(s"WARN: db init failed (${t.getMessage}); rooms will not persist"))
                     })
-      rm         <- Resource.eval(RoomManager.create(repo, dispatcher))
+      gameRecording <- Resource.eval(
+                      (gameRepo.init *> gameRepo.abortStale.flatMap { n =>
+                        IO(println(s"Game recording enabled ($n stale in-progress games marked aborted)"))
+                      }).as(Option(gameRepo)).handleErrorWith { t =>
+                        IO(println(s"WARN: game-record init failed (${t.getMessage}); games will not be recorded"))
+                          .as(None: Option[GameRecordRepo])
+                      })
+      rm         <- Resource.eval(RoomManager.create(repo, dispatcher, gameRecording))
       _          <- Resource.eval(rm.restoreFromDb.handleErrorWith { t =>
                       IO(println(s"WARN: db restore failed: ${t.getMessage}"))
                     })

--- a/server/src/main/scala/io/fele/mahjong/server/RoomManager.scala
+++ b/server/src/main/scala/io/fele/mahjong/server/RoomManager.scala
@@ -20,10 +20,14 @@ import scala.concurrent.ExecutionContext
  */
 class RoomManager private (
   repo:       RoomRepo,
+  gameRepo:   Option[GameRecordRepo],
   dispatcher: Dispatcher[IO],
   cell:       AtomicCell[IO, Map[Models.RoomId, RoomManager.Live]]
 )(implicit config: Config, ec: ExecutionContext) {
   import RoomManager.Live
+
+  /** Fresh explicit seed per game so the shuffle is reproducible from the record. */
+  private def newSeed(): Option[Long] = Some(scala.util.Random.nextLong())
 
   /* --- room CRUD --- */
 
@@ -130,8 +134,8 @@ class RoomManager private (
         case Some(live) if !live.room.isFull =>
           (m, Left("room is not full"))
         case Some(live) =>
-          val runner = GameRunner.create(live.room.id, live.room.seats, None, live.topic, dispatcher,
-            onFinished = autoReadyBots(roomId))
+          val runner = GameRunner.create(live.room.id, live.room.seats, newSeed(), live.topic, dispatcher,
+            onFinished = autoReadyBots(roomId), recordRepo = gameRepo)
           val updated = live.room.copy(status = RoomStatus.Playing)
           (m.updated(roomId, live.copy(room = updated, runner = Some(runner))), Right((updated, runner)))
       }
@@ -197,8 +201,8 @@ class RoomManager private (
         case Some(live) if live.readySeats.size < 4 =>
           (m, IO.pure(Left("not all seats are ready")))
         case Some(live) =>
-          val runner  = GameRunner.create(live.room.id, live.room.seats, None, live.topic, dispatcher,
-            onFinished = autoReadyBots(roomId))
+          val runner  = GameRunner.create(live.room.id, live.room.seats, newSeed(), live.topic, dispatcher,
+            onFinished = autoReadyBots(roomId), recordRepo = gameRepo)
           val updated = live.room.copy(status = RoomStatus.Playing)
           val io = IO.delay(runner.start()) *>
             live.topic.publish1(Json.obj("type" -> "ready_update".asJson, "readySeats" -> Json.arr())).void *>
@@ -224,8 +228,9 @@ class RoomManager private (
 object RoomManager {
   case class Live(room: Models.Room, runner: Option[GameRunner], topic: Topic[IO, Json], readySeats: Set[Int] = Set.empty)
 
-  def create(repo: RoomRepo, dispatcher: Dispatcher[IO])(implicit config: Config, ec: ExecutionContext): IO[RoomManager] =
+  def create(repo: RoomRepo, dispatcher: Dispatcher[IO], gameRepo: Option[GameRecordRepo] = None)
+            (implicit config: Config, ec: ExecutionContext): IO[RoomManager] =
     AtomicCell[IO].of(Map.empty[Models.RoomId, Live]).map { cell =>
-      new RoomManager(repo, dispatcher, cell)
+      new RoomManager(repo, gameRepo, dispatcher, cell)
     }
 }

--- a/server/src/test/scala/io/fele/mahjong/server/GameRecordRepoSpec.scala
+++ b/server/src/test/scala/io/fele/mahjong/server/GameRecordRepoSpec.scala
@@ -1,0 +1,140 @@
+package io.fele.mahjong.server
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import doobie.Transactor
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import io.fele.mahjong.server.Models._
+
+import java.time.Instant
+import java.util.UUID
+
+/** Shared test-DB plumbing. Uses the same dev Postgres as the server
+  * (docker-compose, host port 5433); overridable via MAHJONG_DB_* env vars. */
+object TestDb {
+  private def env(k: String, default: String) = sys.env.getOrElse(k, default)
+
+  val xa: Transactor[IO] = Transactor.fromDriverManager[IO](
+    driver      = env("MAHJONG_DB_DRIVER", "org.postgresql.Driver"),
+    url         = env("MAHJONG_DB_URL", "jdbc:postgresql://localhost:5433/mahjong"),
+    user        = env("MAHJONG_DB_USER", "mahjong"),
+    password    = env("MAHJONG_DB_PASSWORD", "mahjong"),
+    logHandler  = None
+  )
+
+  lazy val available: Boolean = {
+    import doobie.implicits._
+    scala.util.Try(sql"SELECT 1".query[Int].unique.transact(xa).unsafeRunSync()).isSuccess
+  }
+
+  val repo = new GameRecordRepo(xa)
+
+  def sampleSeats: List[Seat] = List(
+    Seat(0, SeatKind.Human,     Some("p0"), "Alice"),
+    Seat(1, SeatKind.AiChicken, None,       "Bot Chicken"),
+    Seat(2, SeatKind.AiRandom,  None,       "Bot Random"),
+    Seat(3, SeatKind.AiFirstFelix, None,    "Bot Felix")
+  )
+}
+
+class GameRecordRepoSpec extends AnyFlatSpec with Matchers {
+  import TestDb._
+
+  private def withGame[A](f: String => A): A = {
+    val id = UUID.randomUUID().toString
+    try f(id) finally repo.deleteGame(id).unsafeRunSync()
+  }
+
+  private val wall = List.fill(34)(List("D1", "B5", "C9", "HW_E")).flatten
+
+  "GameRecordRepo.init" should "be idempotent" in {
+    assume(available, "Postgres not reachable")
+    repo.init.unsafeRunSync()
+    repo.init.unsafeRunSync()
+  }
+
+  "insertGame/getGame" should "round-trip seats, seed, wall and status" in {
+    assume(available, "Postgres not reachable")
+    repo.init.unsafeRunSync()
+    withGame { id =>
+      repo.insertGame(id, "room-1", sampleSeats, Some(42L), wall, Instant.now()).unsafeRunSync()
+      val got = repo.getGame(id).unsafeRunSync().get
+      got.roomId shouldBe "room-1"
+      got.seats shouldBe sampleSeats
+      got.seed shouldBe Some(42L)
+      got.wall should have size 136
+      got.wall shouldBe wall
+      got.status shouldBe GameRecordStatus.InProgress
+      got.outcome shouldBe None
+      got.finishedAt shouldBe None
+    }
+  }
+
+  "insertEvent/eventsFor" should "preserve order and all fields" in {
+    assume(available, "Postgres not reachable")
+    repo.init.unsafeRunSync()
+    withGame { id =>
+      repo.insertGame(id, "room-2", sampleSeats, None, wall, Instant.now()).unsafeRunSync()
+      val now = Instant.now()
+      val rows = List(
+        GameEventRow(id, 0, "start",   None,    None,    None,       None,         now),
+        GameEventRow(id, 1, "draw",    Some(0), None,    Some("D1"), None,         now),
+        GameEventRow(id, 2, "discard", Some(0), None,    Some("D1"), None,         now),
+        GameEventRow(id, 3, "chow",    Some(1), Some(0), Some("D1"), Some("LEFT"), now),
+        GameEventRow(id, 4, "end",     None,    None,    None,       None,         now)
+      )
+      rows.foreach(r => repo.insertEvent(r).unsafeRunSync())
+      val got = repo.eventsFor(id).unsafeRunSync()
+      got.map(_.seq) shouldBe List(0, 1, 2, 3, 4)
+      got.map(_.eventType) shouldBe List("start", "draw", "discard", "chow", "end")
+      got(3).seat shouldBe Some(1)
+      got(3).sourceSeat shouldBe Some(0)
+      got(3).tile shouldBe Some("D1")
+      got(3).chowPosition shouldBe Some("LEFT")
+    }
+  }
+
+  "finishGame" should "store the outcome and flip the status" in {
+    assume(available, "Postgres not reachable")
+    repo.init.unsafeRunSync()
+    withGame { id =>
+      repo.insertGame(id, "room-3", sampleSeats, None, wall, Instant.now()).unsafeRunSync()
+      val outcome = GameOutcome(drawn = false, isSelfWin = false, Some("B5"), Some(2), List(OutcomeWinner(0, 4)))
+      repo.finishGame(id, outcome, Instant.now()).unsafeRunSync()
+      val got = repo.getGame(id).unsafeRunSync().get
+      got.status shouldBe GameRecordStatus.Finished
+      got.outcome shouldBe Some(outcome)
+      got.finishedAt shouldBe defined
+    }
+  }
+
+  "abortGame" should "only touch in-progress games" in {
+    assume(available, "Postgres not reachable")
+    repo.init.unsafeRunSync()
+    withGame { id =>
+      repo.insertGame(id, "room-4", sampleSeats, None, wall, Instant.now()).unsafeRunSync()
+      repo.abortGame(id, Instant.now()).unsafeRunSync()
+      repo.getGame(id).unsafeRunSync().get.status shouldBe GameRecordStatus.Aborted
+
+      // a finished game must not be re-marked
+      withGame { id2 =>
+        repo.insertGame(id2, "room-4", sampleSeats, None, wall, Instant.now()).unsafeRunSync()
+        repo.finishGame(id2, GameOutcome(drawn = true, isSelfWin = false, None, None, Nil), Instant.now()).unsafeRunSync()
+        repo.abortGame(id2, Instant.now()).unsafeRunSync()
+        repo.getGame(id2).unsafeRunSync().get.status shouldBe GameRecordStatus.Finished
+      }
+    }
+  }
+
+  "deleteGame" should "cascade to events" in {
+    assume(available, "Postgres not reachable")
+    repo.init.unsafeRunSync()
+    val id = UUID.randomUUID().toString
+    repo.insertGame(id, "room-5", sampleSeats, None, wall, Instant.now()).unsafeRunSync()
+    repo.insertEvent(GameEventRow(id, 0, "start", None, None, None, None, Instant.now())).unsafeRunSync()
+    repo.deleteGame(id).unsafeRunSync()
+    repo.getGame(id).unsafeRunSync() shouldBe None
+    repo.eventsFor(id).unsafeRunSync() shouldBe Nil
+  }
+}

--- a/server/src/test/scala/io/fele/mahjong/server/GameRecordingSpec.scala
+++ b/server/src/test/scala/io/fele/mahjong/server/GameRecordingSpec.scala
@@ -1,0 +1,130 @@
+package io.fele.mahjong.server
+
+import cats.effect.IO
+import cats.effect.std.Dispatcher
+import cats.effect.unsafe.implicits.global
+import fs2.concurrent.Topic
+import io.circe.Json
+import io.fele.app.mahjong.{Config => EngineConfig, RandomTileDrawer}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import io.fele.mahjong.server.Models._
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
+
+/** End-to-end: run a real bot game through [[GameRunner]] with recording on and
+  * verify the persisted record is complete and replay-consistent. This is the
+  * same code path human games take — only the Player implementations differ. */
+class GameRecordingSpec extends AnyFlatSpec with Matchers {
+  import TestDb.{available, repo}
+
+  implicit val engineConfig: EngineConfig = new EngineConfig()
+  implicit val ec: ExecutionContext = ExecutionContext.global
+
+  private val botSeats = List(
+    Seat(0, SeatKind.AiChicken,           None, "Bot A"),
+    Seat(1, SeatKind.AiRandom,            None, "Bot B"),
+    Seat(2, SeatKind.AiFirstFelix,        None, "Bot C"),
+    Seat(3, SeatKind.AiThreePointChicken, None, "Bot D")
+  )
+
+  private def runBotGame(seed: Long): GameRunner = {
+    val runner = Dispatcher.parallel[IO].allocated.flatMap { case (dispatcher, release) =>
+      for {
+        topic  <- Topic[IO, Json]
+        runner <- IO.delay(GameRunner.create(
+                    "test-room", botSeats, Some(seed), topic, dispatcher, recordRepo = Some(repo)))
+        _      <- IO.delay(runner.start())
+        _      <- waitFinished(runner, 30.seconds)
+        _      <- release
+      } yield runner
+    }.unsafeRunSync()
+    runner
+  }
+
+  private def waitFinished(runner: GameRunner, timeout: FiniteDuration): IO[Unit] =
+    if (timeout <= Duration.Zero) IO.raiseError(new RuntimeException("game did not finish in time"))
+    else if (runner.isFinished) IO.unit
+    else IO.sleep(100.millis) >> waitFinished(runner, timeout - 100.millis)
+
+  "a recorded bot game" should "persist a complete, replay-consistent event stream" in {
+    assume(available, "Postgres not reachable")
+    repo.init.unsafeRunSync()
+
+    val seed   = 20260722L
+    val runner = runBotGame(seed)
+    val gameId = runner.recorder.get.gameId
+    try {
+      val game   = repo.getGame(gameId).unsafeRunSync().get
+      val events = repo.eventsFor(gameId).unsafeRunSync()
+
+      // game row
+      game.roomId shouldBe "test-room"
+      game.seats shouldBe botSeats
+      game.seed shouldBe Some(seed)
+      game.status shouldBe GameRecordStatus.Finished
+      game.finishedAt shouldBe defined
+      game.outcome shouldBe defined
+      game.wall should have size 136
+
+      // the persisted wall is exactly what the seed regenerates
+      val regenerated = new RandomTileDrawer(Some(seed)).drawerState.shuffledTiles.map(Models.tileToWire).toList
+      game.wall shouldBe regenerated
+
+      // event stream shape
+      events.map(_.seq) shouldBe events.indices.toList
+      events.head.eventType shouldBe "start"
+      events.last.eventType shouldBe "end"
+      events.count(_.eventType == "end") shouldBe 1
+      events.map(_.ts).sliding(2).foreach { case List(a, b) => assert(!b.isBefore(a)); case _ => () }
+
+      // replay consistency: the initial 4x13 deal comes off the front of the
+      // wall, and every draw (incl. post-kong replacement draws) pops the wall
+      // sequentially from position 52
+      val draws = events.filter(_.eventType == "draw").flatMap(_.tile)
+      draws should not be empty
+      draws shouldBe game.wall.slice(52, 52 + draws.size)
+
+      // every non-terminal event carries an acting seat and a tile
+      events.filter(e => e.eventType != "start" && e.eventType != "end").foreach { e =>
+        e.seat shouldBe defined
+        e.tile shouldBe defined
+      }
+      events.filter(_.eventType == "chow").foreach(_.chowPosition shouldBe defined)
+      events.filter(e => e.eventType == "pong" || e.eventType == "chow").foreach { e =>
+        e.sourceSeat shouldBe defined
+        e.sourceSeat should not be e.seat
+      }
+
+      // outcome matches the engine's final state
+      val outcome = game.outcome.get
+      if (outcome.drawn) {
+        runner.state.winnersInfo shouldBe None
+        outcome.winners shouldBe Nil
+      } else {
+        val wi = runner.state.winnersInfo.get
+        outcome.isSelfWin shouldBe wi.isSelfWin
+        outcome.winningTile shouldBe Some(Models.tileToWire(wi.winningTile))
+        outcome.loserSeat shouldBe wi.loserId
+        outcome.winners.map(w => (w.seat, w.score)).toSet shouldBe wi.winners.map(w => (w.id, w.score))
+      }
+    } finally repo.deleteGame(gameId).unsafeRunSync()
+  }
+
+  it should "record identical walls for identical seeds" in {
+    assume(available, "Postgres not reachable")
+    repo.init.unsafeRunSync()
+
+    val r1 = runBotGame(7L)
+    val r2 = runBotGame(7L)
+    try {
+      val g1 = repo.getGame(r1.recorder.get.gameId).unsafeRunSync().get
+      val g2 = repo.getGame(r2.recorder.get.gameId).unsafeRunSync().get
+      g1.wall shouldBe g2.wall
+    } finally {
+      repo.deleteGame(r1.recorder.get.gameId).unsafeRunSync()
+      repo.deleteGame(r2.recorder.get.gameId).unsafeRunSync()
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Implements the first concrete task of #30: log the complete per-game event stream to Postgres so human (and bot) games stop being thrown away. Two new tables, created idempotently on boot:

- **`game_records`** — one row per game: room id, seats (player identity + kind), an explicit RNG seed (previously always `None`, i.e. games were unreproducible), the **full 136-tile wall in draw order**, status (`in_progress` / `finished` / `aborted`), outcome (winners/scores/loser/winning tile/self-win/drawn), started/finished timestamps.
- **`game_events`** — the ordered engine event stream: `start | resume | draw | discard | kong | pong | chow | end` with acting seat, source seat (claimed discards; `== seat` for self-kong), tile, chow position, and a per-event timestamp.

**Events, not observations** (as the issue specifies): wall + seats + event stream is sufficient for the Scala engine to deterministically replay a game and reconstruct every hidden hand at every decision point, at any future obs version. The hook is the same `GameLogger` mechanism `BeliefDataGen` uses.

## Design notes

- `GameRecorder` writes synchronously on the dedicated per-game engine thread → events are strictly ordered and durable the moment each decision is made. An abandoned game keeps every decision up to the abandonment — still usable data.
- A DB error disables recording for that game (with a warning) rather than crashing gameplay; if table init fails at boot the server runs with recording off, mirroring the existing `RoomRepo` degradation.
- Games left `in_progress` by a dead process are marked `aborted` on next boot (runners aren't restored across restarts).
- Bot seats exercise the identical logging path as human seats, so existing Playwright e2e + bot games cover it.

## Tests (first tests in the server module)

- `GameRecordRepoSpec`: init idempotency, full round-trip of seats/seed/wall/outcome, event ordering + fields, abort-only-touches-in-progress, cascade delete. Runs against the docker-compose Postgres (skips if unreachable).
- `GameRecordingSpec` (end-to-end): runs real bot games through `GameRunner` with recording on and asserts replay consistency — the persisted seed regenerates the persisted wall exactly, the deal is `wall[0..52)`, and every draw event (incl. post-kong replacement draws) matches the wall sequence from position 52; outcome matches the engine's final state.
- Live smoke test performed: server boot logs `Game recording enabled`, REST-driven game creates the record + `start`/`draw` events, restart marks it `aborted`.

`Test / parallelExecution := false` for the server module — suites share one Postgres and would race on `CREATE TABLE IF NOT EXISTS`.

Part of #30 (step 1 of the flywheel; steps 2–3 depend on this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A8JbBsdzSQNNAB4xNbFoYC