### PR TITLE
server+web: champion (net D) playable as a bot seat (#30)

### DIFF
--- a/server/src/main/resources/application.conf
+++ b/server/src/main/resources/application.conf
@@ -5,6 +5,13 @@ server {
   port = ${?MAHJONG_SERVER_PORT}
 }
 
+champion {
+  # ONNX export of the champion policy net (net D). Relative paths resolve
+  # against the server's working directory (repo root in dev).
+  modelPath = "rl/checkpoints/best_raw_net.onnx"
+  modelPath = ${?MAHJONG_CHAMPION_MODEL}
+}
+
 db {
   url      = "jdbc:postgresql://localhost:5433/mahjong"
   url      = ${?MAHJONG_DB_URL}

--- a/server/src/main/scala/io/fele/mahjong/server/ChampionService.scala
+++ b/server/src/main/scala/io/fele/mahjong/server/ChampionService.scala
@@ -1,0 +1,31 @@
+package io.fele.mahjong.server
+
+import com.typesafe.config.ConfigFactory
+import io.fele.app.mahjong.rl.OnnxPolicyService
+
+/** Process-wide ONNX session for the champion policy net (net D).
+  *
+  * One [[OnnxPolicyService]] serves every AiChampion seat in every room: its
+  * internal daemon thread batches concurrent queries, and game threads block
+  * on their own futures, so sharing is both safe and the intended usage.
+  * Loading is lazy — a server without the model file still runs, it just
+  * refuses to start games that seat a champion.
+  */
+object ChampionService {
+
+  lazy val modelPath: String = ConfigFactory.load().getString("champion.modelPath")
+
+  lazy val service: Either[String, OnnxPolicyService] = {
+    val f = new java.io.File(modelPath)
+    if (!f.isFile) Left(s"champion model not found at $modelPath (set MAHJONG_CHAMPION_MODEL)")
+    else
+      try Right(new OnnxPolicyService(f.getAbsolutePath))
+      catch { case t: Throwable => Left(s"failed to load champion model $modelPath: ${t.getMessage}") }
+  }
+
+  /** Error message when the champion cannot play, None when it can. */
+  def unavailableReason: Option[String] = service.left.toOption
+
+  def instance: OnnxPolicyService =
+    service.fold(e => throw new IllegalStateException(e), identity)
+}

--- a/server/src/main/scala/io/fele/mahjong/server/GameRunner.scala
+++ b/server/src/main/scala/io/fele/mahjong/server/GameRunner.scala
@@ -221,6 +221,7 @@ object GameRunner {
         case SeatKind.AiRandom            => new RandomDiscard(seat.index, hand)
         case SeatKind.AiFirstFelix        => new FirstFelix(seat.index, hand, 5)
         case SeatKind.AiThreePointChicken => new ThreePointChicken(seat.index, hand)
+        case SeatKind.AiChampion          => new rl.NNPlayer(seat.index, hand, Nil, ChampionService.instance)
         case SeatKind.Open                => new Chicken(seat.index, hand)
       }
     }

--- a/server/src/main/scala/io/fele/mahjong/server/Main.scala
+++ b/server/src/main/scala/io/fele/mahjong/server/Main.scala
@@ -45,6 +45,10 @@ object Main extends IOApp {
                         IO(println(s"WARN: game-record init failed (${t.getMessage}); games will not be recorded"))
                           .as(None: Option[GameRecordRepo])
                       })
+      _          <- Resource.eval(IO(ChampionService.unavailableReason match {
+                      case None    => println(s"Champion bot enabled (model: ${ChampionService.modelPath})")
+                      case Some(e) => println(s"WARN: champion bot unavailable: $e")
+                    }))
       rm         <- Resource.eval(RoomManager.create(repo, dispatcher, gameRecording))
       _          <- Resource.eval(rm.restoreFromDb.handleErrorWith { t =>
                       IO(println(s"WARN: db restore failed: ${t.getMessage}"))

--- a/server/src/main/scala/io/fele/mahjong/server/Models.scala
+++ b/server/src/main/scala/io/fele/mahjong/server/Models.scala
@@ -24,9 +24,10 @@ object Models {
     case object AiRandom             extends SeatKind
     case object AiFirstFelix         extends SeatKind
     case object AiThreePointChicken  extends SeatKind
+    case object AiChampion           extends SeatKind   // champion policy net (greedy NNPlayer)
     case object Open                 extends SeatKind   // unfilled human slot waiting for someone
 
-    val all: List[SeatKind] = List(Human, AiChicken, AiRandom, AiFirstFelix, AiThreePointChicken, Open)
+    val all: List[SeatKind] = List(Human, AiChicken, AiRandom, AiFirstFelix, AiThreePointChicken, AiChampion, Open)
 
     def fromString(s: String): Option[SeatKind] = s.toLowerCase match {
       case "human"               => Some(Human)
@@ -35,6 +36,7 @@ object Models {
       case "ai_random"           => Some(AiRandom)
       case "ai_first_felix"      => Some(AiFirstFelix)
       case "ai_3point_chicken"   => Some(AiThreePointChicken)
+      case "ai_champion"         => Some(AiChampion)
       case _                     => None
     }
 
@@ -45,6 +47,7 @@ object Models {
       case AiRandom             => "ai_random"
       case AiFirstFelix         => "ai_first_felix"
       case AiThreePointChicken  => "ai_3point_chicken"
+      case AiChampion           => "ai_champion"
     }
 
     implicit val enc: Encoder[SeatKind] = Encoder.encodeString.contramap(toWire)

--- a/server/src/main/scala/io/fele/mahjong/server/RoomManager.scala
+++ b/server/src/main/scala/io/fele/mahjong/server/RoomManager.scala
@@ -29,6 +29,10 @@ class RoomManager private (
   /** Fresh explicit seed per game so the shuffle is reproducible from the record. */
   private def newSeed(): Option[Long] = Some(scala.util.Random.nextLong())
 
+  /** Reason a game with a champion seat cannot start (model missing/broken), if any. */
+  private def championBlocked(room: Room): Option[String] =
+    if (room.seats.exists(_.kind == SeatKind.AiChampion)) ChampionService.unavailableReason else None
+
   /* --- room CRUD --- */
 
   def create(name: String, hostName: String): IO[(Room, PlayerId)] = {
@@ -86,6 +90,7 @@ class RoomManager private (
     case SeatKind.AiRandom            => "Bot Random"
     case SeatKind.AiFirstFelix        => "Bot Felix"
     case SeatKind.AiThreePointChicken => "Bot 3PChicken"
+    case SeatKind.AiChampion          => "Bot Champion"
     case _                            => s"Seat ${idx + 1}"
   }
 
@@ -133,6 +138,8 @@ class RoomManager private (
           (m, Left("game already started"))
         case Some(live) if !live.room.isFull =>
           (m, Left("room is not full"))
+        case Some(live) if championBlocked(live.room).isDefined =>
+          (m, Left(championBlocked(live.room).get))
         case Some(live) =>
           val runner = GameRunner.create(live.room.id, live.room.seats, newSeed(), live.topic, dispatcher,
             onFinished = autoReadyBots(roomId), recordRepo = gameRepo)
@@ -200,6 +207,8 @@ class RoomManager private (
           (m, IO.pure(Left("game has not finished yet")))
         case Some(live) if live.readySeats.size < 4 =>
           (m, IO.pure(Left("not all seats are ready")))
+        case Some(live) if championBlocked(live.room).isDefined =>
+          (m, IO.pure(Left(championBlocked(live.room).get): Either[String, Room]))
         case Some(live) =>
           val runner  = GameRunner.create(live.room.id, live.room.seats, newSeed(), live.topic, dispatcher,
             onFinished = autoReadyBots(roomId), recordRepo = gameRepo)

--- a/server/src/test/scala/io/fele/mahjong/server/ChampionSeatSpec.scala
+++ b/server/src/test/scala/io/fele/mahjong/server/ChampionSeatSpec.scala
@@ -1,0 +1,71 @@
+package io.fele.mahjong.server
+
+import cats.effect.IO
+import cats.effect.std.Dispatcher
+import cats.effect.unsafe.implicits.global
+import fs2.concurrent.Topic
+import io.circe.Json
+import io.fele.app.mahjong.{Config => EngineConfig}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import io.fele.mahjong.server.Models._
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
+
+/** The champion (net D) plays a full game through the same GameRunner path as
+  * every other seat. Skipped when the ONNX export or Postgres is unavailable. */
+class ChampionSeatSpec extends AnyFlatSpec with Matchers {
+  import TestDb.{available, repo}
+
+  implicit val engineConfig: EngineConfig = new EngineConfig()
+  implicit val ec: ExecutionContext = ExecutionContext.global
+
+  "SeatKind" should "round-trip ai_champion on the wire" in {
+    SeatKind.fromString("ai_champion") shouldBe Some(SeatKind.AiChampion)
+    SeatKind.toWire(SeatKind.AiChampion) shouldBe "ai_champion"
+    SeatKind.all should contain(SeatKind.AiChampion)
+  }
+
+  "a champion-seated bot game" should "run to completion and be recorded" in {
+    assume(available, "Postgres not reachable")
+    assume(ChampionService.unavailableReason.isEmpty,
+      s"champion model unavailable: ${ChampionService.unavailableReason.getOrElse("")}")
+    repo.init.unsafeRunSync()
+
+    val seats = List(
+      Seat(0, SeatKind.AiChampion,   None, "Bot Champion"),
+      Seat(1, SeatKind.AiFirstFelix, None, "Bot Felix"),
+      Seat(2, SeatKind.AiFirstFelix, None, "Bot Felix"),
+      Seat(3, SeatKind.AiFirstFelix, None, "Bot Felix")
+    )
+
+    val runner = Dispatcher.parallel[IO].allocated.flatMap { case (dispatcher, release) =>
+      for {
+        topic  <- Topic[IO, Json]
+        runner <- IO.delay(GameRunner.create(
+                    "champion-test", seats, Some(123L), topic, dispatcher, recordRepo = Some(repo)))
+        _      <- IO.delay(runner.start())
+        _      <- waitFinished(runner, 60.seconds)
+        _      <- release
+      } yield runner
+    }.unsafeRunSync()
+
+    val gameId = runner.recorder.get.gameId
+    try {
+      val game   = repo.getGame(gameId).unsafeRunSync().get
+      val events = repo.eventsFor(gameId).unsafeRunSync()
+      game.status shouldBe GameRecordStatus.Finished
+      game.seats.head.kind shouldBe SeatKind.AiChampion
+      events.head.eventType shouldBe "start"
+      events.last.eventType shouldBe "end"
+      // the champion actually acted: seat 0 drew and discarded like any player
+      events.exists(e => e.eventType == "draw" && e.seat.contains(0)) shouldBe true
+    } finally repo.deleteGame(gameId).unsafeRunSync()
+  }
+
+  private def waitFinished(runner: GameRunner, timeout: FiniteDuration): IO[Unit] =
+    if (timeout <= Duration.Zero) IO.raiseError(new RuntimeException("game did not finish in time"))
+    else if (runner.isFinished) IO.unit
+    else IO.sleep(100.millis) >> waitFinished(runner, timeout - 100.millis)
+}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -4,13 +4,15 @@ export type SeatKind =
   | "ai_chicken"
   | "ai_random"
   | "ai_first_felix"
-  | "ai_3point_chicken";
+  | "ai_3point_chicken"
+  | "ai_champion";
 
 export const AI_KINDS: SeatKind[] = [
   "ai_chicken",
   "ai_random",
   "ai_first_felix",
   "ai_3point_chicken",
+  "ai_champion",
 ];
 
 export const seatLabel: Record<SeatKind, string> = {
@@ -20,6 +22,7 @@ export const seatLabel: Record<SeatKind, string> = {
   ai_random: "AI – Random",
   ai_first_felix: "AI – Felix",
   ai_3point_chicken: "AI – 3-point Chicken",
+  ai_champion: "AI – Champion",
 };
 
 export interface Seat {


### PR DESCRIPTION
## Summary

Adds `SeatKind.AiChampion` so the champion policy net (net D) can sit at any web table. This is the missing prerequisite for step 3.1 of #30 — champion-vs-human evaluation, the first benchmark outside the bot family. With game-record persistence (#31) already on master, every champion game (bot or human opponents) is captured automatically from the moment this merges.

- **Engine wiring**: `GameRunner` maps the new seat kind to core's existing `NNPlayer` (greedy masked argmax, `rl/NNRollout.scala`). A single process-wide `OnnxPolicyService` serves all champion seats — its internal batching daemon is designed for concurrent callers, so one session is shared across rooms.
- **Model config**: defaults to `rl/checkpoints/best_raw_net.onnx` (the measured-final champion per #29), overridable via `MAHJONG_CHAMPION_MODEL` / `champion.modelPath`.
- **Graceful degradation**: a server without the model boots with a warning; starting a champion-seated game returns a clean 400 with an actionable message (guarded in both `startGame` and `startNextGame`) rather than killing the game thread mid-flight.
- **Web**: `ai_champion` added to the seat-kind union, `AI_KINDS`, and labels ("AI – Champion"); the seat picker derives from these, so no component changes.

## Testing

- New `ChampionSeatSpec`: wire round-trip, plus a full champion-seated bot game through `GameRunner` — finishes, is recorded, and the champion demonstrably acts. Runs against the real ONNX model (skips cleanly if model or Postgres is absent). All 10 server tests green; `tsc --noEmit` clean.
- Live REST smoke: boot logs `Champion bot enabled`, seats patch to `ai_champion` ("Bot Champion"), game starts and records with champion seats; with `MAHJONG_CHAMPION_MODEL=/nonexistent` the boot warns and start returns `400 {"error":"champion model not found …"}`.

Part of #30 (enables step 3.1; next up is the private dogfood deploy, step 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A8JbBsdzSQNNAB4xNbFoYC