### PR TITLE
deploy+server: survive Postgres outages instead of silently dropping game records

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       interval: 5s
       timeout:  3s
       retries:  10
+    restart: unless-stopped
 
   # --- dogfood deploy (issue #30 step 2): docker compose --profile app up -d --build ---
   # PUBLIC_HOST is the name/IP browsers use to reach this machine; defaults to

--- a/server/src/main/scala/io/fele/mahjong/server/Main.scala
+++ b/server/src/main/scala/io/fele/mahjong/server/Main.scala
@@ -11,8 +11,20 @@ import org.http4s.ember.server.EmberServerBuilder
 import org.http4s.server.Router
 
 import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
 
 object Main extends IOApp {
+
+  private val DbInitAttempts = 30
+  private val DbInitDelay    = 2.seconds
+
+  private def withDbRetry[A](what: String, attemptsLeft: Int = DbInitAttempts)(io: IO[A]): IO[A] =
+    io.handleErrorWith { t =>
+      if (attemptsLeft <= 1) IO.raiseError(t)
+      else
+        IO(println(s"$what: Postgres not ready (${t.getMessage}); retrying in $DbInitDelay ($attemptsLeft attempts left)")) *>
+          IO.sleep(DbInitDelay) *> withDbRetry(what, attemptsLeft - 1)(io)
+    }
 
   override def run(args: List[String]): IO[ExitCode] = {
     val tcCfg = ConfigFactory.load()
@@ -35,13 +47,16 @@ object Main extends IOApp {
       repo        = new RoomRepo(xa)
       gameRepo    = new GameRecordRepo(xa)
       _          <- Resource.eval(IO(println(s"Connecting to Postgres at $dbUrl")))
-      _          <- Resource.eval(repo.init.handleErrorWith { t =>
+      // Docker restart policies don't honor depends_on ordering after a daemon
+      // restart, so Postgres may come up after us — retry before degrading.
+      _          <- Resource.eval(withDbRetry("db init")(repo.init).handleErrorWith { t =>
                       IO(println(s"WARN: db init failed (${t.getMessage}); rooms will not persist"))
                     })
       gameRecording <- Resource.eval(
-                      (gameRepo.init *> gameRepo.abortStale.flatMap { n =>
+                      withDbRetry("game-record init")(gameRepo.init *> gameRepo.abortStale).flatMap { n =>
                         IO(println(s"Game recording enabled ($n stale in-progress games marked aborted)"))
-                      }).as(Option(gameRepo)).handleErrorWith { t =>
+                          .as(Option(gameRepo))
+                      }.handleErrorWith { t =>
                         IO(println(s"WARN: game-record init failed (${t.getMessage}); games will not be recorded"))
                           .as(None: Option[GameRecordRepo])
                       })


### PR DESCRIPTION
## Problem

The dogfood stack (#30 step 2) had been **silently not recording games for ~7 days**. The `postgres` service had no restart policy, while `server`/`web` had `unless-stopped` — so after a host/daemon restart, server and web came back but postgres stayed down. The server attempts its DB connection exactly once at startup, logs a WARN, and keeps serving with recording disabled. `game_records` count: 0.

## Fix

- **docker-compose.yml**: `restart: unless-stopped` on postgres, matching the other services.
- **Main.scala**: retry DB init (rooms + game records) with 2s backoff for up to 60s before degrading. This is needed even with the restart policy, because Docker restart policies don't honor `depends_on` ordering after a daemon restart — the server can come up before postgres is healthy.

## Verification

- `sbt server/test`: 10/10 pass.
- Live failure simulation on the dogfood stack: stopped postgres, restarted server → observed `db init: Postgres not ready ... retrying in 2 seconds`, started postgres mid-retry → `Game recording enabled`. Stack is redeployed with the fix and recording is confirmed on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)