### PR TITLE
server: /api/health reports live game-recording status

### DIFF
--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -29,7 +29,11 @@ Without `--profile app`, `docker compose up` still starts Postgres only
 ## Checks
 
 ```bash
-curl http://localhost:8080/api/health          # {"status":"ok"}
+curl http://localhost:8080/api/health
+# 200 {"status":"ok","recording":true,"gamesRecorded":N,"recordingError":null,"champion":"ok"}
+# 503 {"status":"degraded","recording":false,...} when game recording is down —
+#     the health check does a live DB round-trip, so a dead Postgres shows up
+#     here immediately instead of only in the boot logs.
 docker compose logs server | grep -E "Champion|recording"
 #   Game recording enabled (N stale in-progress games marked aborted)
 #   Champion bot enabled (model: /app/model/best_raw_net.onnx)

--- a/server/src/main/scala/io/fele/mahjong/server/GameRecordRepo.scala
+++ b/server/src/main/scala/io/fele/mahjong/server/GameRecordRepo.scala
@@ -165,6 +165,10 @@ class GameRecordRepo(xa: Transactor[IO]) {
     """.update.run.transact(xa)
   }
 
+  /** Total games recorded. Doubles as a live DB reachability probe for /api/health. */
+  def countGames: IO[Long] =
+    sql"""SELECT count(*) FROM game_records""".query[Long].unique.transact(xa)
+
   def getGame(id: String): IO[Option[GameRecordRow]] =
     sql"""
       SELECT id, room_id, seats_json, seed, wall_json, status, outcome_json, started_at, finished_at

--- a/server/src/main/scala/io/fele/mahjong/server/Main.scala
+++ b/server/src/main/scala/io/fele/mahjong/server/Main.scala
@@ -55,10 +55,10 @@ object Main extends IOApp {
       gameRecording <- Resource.eval(
                       withDbRetry("game-record init")(gameRepo.init *> gameRepo.abortStale).flatMap { n =>
                         IO(println(s"Game recording enabled ($n stale in-progress games marked aborted)"))
-                          .as(Option(gameRepo))
+                          .as(Right(gameRepo): Either[String, GameRecordRepo])
                       }.handleErrorWith { t =>
                         IO(println(s"WARN: game-record init failed (${t.getMessage}); games will not be recorded"))
-                          .as(None: Option[GameRecordRepo])
+                          .as(Left(s"init failed at boot: ${t.getMessage}"): Either[String, GameRecordRepo])
                       })
       _          <- Resource.eval(IO(ChampionService.unavailableReason match {
                       case None    => println(s"Champion bot enabled (model: ${ChampionService.modelPath})")

--- a/server/src/main/scala/io/fele/mahjong/server/RoomManager.scala
+++ b/server/src/main/scala/io/fele/mahjong/server/RoomManager.scala
@@ -12,6 +12,7 @@ import io.fele.mahjong.server.Models._
 import java.time.Instant
 import java.util.UUID
 import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
 
 /**
  * Coordinates room CRUD and the live in-memory game runners. All mutating
@@ -20,7 +21,7 @@ import scala.concurrent.ExecutionContext
  */
 class RoomManager private (
   repo:       RoomRepo,
-  gameRepo:   Option[GameRecordRepo],
+  gameRepo:   Either[String, GameRecordRepo],
   dispatcher: Dispatcher[IO],
   cell:       AtomicCell[IO, Map[Models.RoomId, RoomManager.Live]]
 )(implicit config: Config, ec: ExecutionContext) {
@@ -34,11 +35,13 @@ class RoomManager private (
     if (room.seats.exists(_.kind == SeatKind.AiChampion)) ChampionService.unavailableReason else None
 
   /** Live game-recording probe: Left(reason) when recording is off or the DB is
-    * unreachable right now, Right(total games recorded) when the path works. */
+    * unreachable right now, Right(total games recorded) when the path works.
+    * The probe is time-boxed so a network partition (vs a clean refusal)
+    * degrades the health check instead of hanging it. */
   def recordingHealth: IO[Either[String, Long]] = gameRepo match {
-    case None => IO.pure(Left("recording disabled (DB unavailable at boot)"))
-    case Some(repo) =>
-      repo.countGames.attempt.map {
+    case Left(reason) => IO.pure(Left(s"recording disabled ($reason)"))
+    case Right(repo) =>
+      repo.countGames.timeout(5.seconds).attempt.map {
         case Right(n) => Right(n)
         case Left(t)  => Left(s"db unreachable: ${t.getMessage}")
       }
@@ -153,7 +156,7 @@ class RoomManager private (
           (m, Left(championBlocked(live.room).get))
         case Some(live) =>
           val runner = GameRunner.create(live.room.id, live.room.seats, newSeed(), live.topic, dispatcher,
-            onFinished = autoReadyBots(roomId), recordRepo = gameRepo)
+            onFinished = autoReadyBots(roomId), recordRepo = gameRepo.toOption)
           val updated = live.room.copy(status = RoomStatus.Playing)
           (m.updated(roomId, live.copy(room = updated, runner = Some(runner))), Right((updated, runner)))
       }
@@ -222,7 +225,7 @@ class RoomManager private (
           (m, IO.pure(Left(championBlocked(live.room).get): Either[String, Room]))
         case Some(live) =>
           val runner  = GameRunner.create(live.room.id, live.room.seats, newSeed(), live.topic, dispatcher,
-            onFinished = autoReadyBots(roomId), recordRepo = gameRepo)
+            onFinished = autoReadyBots(roomId), recordRepo = gameRepo.toOption)
           val updated = live.room.copy(status = RoomStatus.Playing)
           val io = IO.delay(runner.start()) *>
             live.topic.publish1(Json.obj("type" -> "ready_update".asJson, "readySeats" -> Json.arr())).void *>
@@ -248,7 +251,8 @@ class RoomManager private (
 object RoomManager {
   case class Live(room: Models.Room, runner: Option[GameRunner], topic: Topic[IO, Json], readySeats: Set[Int] = Set.empty)
 
-  def create(repo: RoomRepo, dispatcher: Dispatcher[IO], gameRepo: Option[GameRecordRepo] = None)
+  def create(repo: RoomRepo, dispatcher: Dispatcher[IO],
+             gameRepo: Either[String, GameRecordRepo] = Left("not configured"))
             (implicit config: Config, ec: ExecutionContext): IO[RoomManager] =
     AtomicCell[IO].of(Map.empty[Models.RoomId, Live]).map { cell =>
       new RoomManager(repo, gameRepo, dispatcher, cell)

--- a/server/src/main/scala/io/fele/mahjong/server/RoomManager.scala
+++ b/server/src/main/scala/io/fele/mahjong/server/RoomManager.scala
@@ -33,6 +33,17 @@ class RoomManager private (
   private def championBlocked(room: Room): Option[String] =
     if (room.seats.exists(_.kind == SeatKind.AiChampion)) ChampionService.unavailableReason else None
 
+  /** Live game-recording probe: Left(reason) when recording is off or the DB is
+    * unreachable right now, Right(total games recorded) when the path works. */
+  def recordingHealth: IO[Either[String, Long]] = gameRepo match {
+    case None => IO.pure(Left("recording disabled (DB unavailable at boot)"))
+    case Some(repo) =>
+      repo.countGames.attempt.map {
+        case Right(n) => Right(n)
+        case Left(t)  => Left(s"db unreachable: ${t.getMessage}")
+      }
+  }
+
   /* --- room CRUD --- */
 
   def create(name: String, hostName: String): IO[(Room, PlayerId)] = {

--- a/server/src/main/scala/io/fele/mahjong/server/Routes.scala
+++ b/server/src/main/scala/io/fele/mahjong/server/Routes.scala
@@ -40,8 +40,20 @@ object Routes {
 
   def routes(rm: RoomManager): HttpRoutes[IO] = HttpRoutes.of[IO] {
 
+    /* Health: 200/ok only when game recording is live (repo wired AND DB
+     * reachable right now); 503/degraded otherwise so uptime checks catch a
+     * silent recording outage (the #34 failure mode) without reading logs. */
     case GET -> Root / "api" / "health" =>
-      Ok(Map("status" -> "ok").asJson)
+      rm.recordingHealth.flatMap { rec =>
+        val body = io.circe.Json.obj(
+          "status"         -> (if (rec.isRight) "ok" else "degraded").asJson,
+          "recording"      -> rec.isRight.asJson,
+          "gamesRecorded"  -> rec.toOption.asJson,
+          "recordingError" -> rec.left.toOption.asJson,
+          "champion"       -> ChampionService.unavailableReason.fold("ok")(e => s"unavailable: $e").asJson
+        )
+        if (rec.isRight) Ok(body) else ServiceUnavailable(body)
+      }
 
     /* List rooms */
     case GET -> Root / "api" / "rooms" =>

--- a/server/src/test/scala/io/fele/mahjong/server/HealthRouteSpec.scala
+++ b/server/src/test/scala/io/fele/mahjong/server/HealthRouteSpec.scala
@@ -1,0 +1,58 @@
+package io.fele.mahjong.server
+
+import cats.effect.IO
+import cats.effect.std.Dispatcher
+import cats.effect.unsafe.implicits.global
+import io.circe.Json
+import io.fele.app.mahjong.{Config => EngineConfig}
+import org.http4s._
+import org.http4s.circe.CirceEntityCodec._
+import org.http4s.implicits._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.concurrent.ExecutionContext
+
+/** /api/health must expose the game-recording state: 200/ok when the record
+  * repo is wired and the DB answers, 503/degraded when recording is off —
+  * the silent-outage mode fixed in #34. */
+class HealthRouteSpec extends AnyFlatSpec with Matchers {
+  import TestDb.{available, repo, xa}
+
+  implicit val engineConfig: EngineConfig = new EngineConfig()
+  implicit val ec: ExecutionContext = ExecutionContext.global
+
+  private def healthResponse(gameRepo: Option[GameRecordRepo]): (Status, Json) =
+    Dispatcher.parallel[IO].use { dispatcher =>
+      for {
+        rm   <- RoomManager.create(new RoomRepo(xa), dispatcher, gameRepo)
+        resp <- Routes.routes(rm).orNotFound.run(Request[IO](Method.GET, uri"/api/health"))
+        body <- resp.as[Json]
+      } yield (resp.status, body)
+    }.unsafeRunSync()
+
+  private def field(body: Json, name: String): Json =
+    body.hcursor.downField(name).focus.getOrElse(Json.Null)
+
+  "GET /api/health" should "report ok with a games-recorded count when recording is live" in {
+    assume(available, "Postgres not reachable")
+    repo.init.unsafeRunSync()
+
+    val (status, body) = healthResponse(Some(repo))
+    status shouldBe Status.Ok
+    field(body, "status").asString shouldBe Some("ok")
+    field(body, "recording").asBoolean shouldBe Some(true)
+    field(body, "gamesRecorded").asNumber.flatMap(_.toLong).getOrElse(-1L) should be >= 0L
+    field(body, "recordingError") shouldBe Json.Null
+  }
+
+  it should "report degraded with 503 when recording is disabled" in {
+    assume(available, "Postgres not reachable")
+
+    val (status, body) = healthResponse(None)
+    status shouldBe Status.ServiceUnavailable
+    field(body, "status").asString shouldBe Some("degraded")
+    field(body, "recording").asBoolean shouldBe Some(false)
+    field(body, "recordingError").asString.getOrElse("") should include("disabled")
+  }
+}

--- a/server/src/test/scala/io/fele/mahjong/server/HealthRouteSpec.scala
+++ b/server/src/test/scala/io/fele/mahjong/server/HealthRouteSpec.scala
@@ -22,7 +22,7 @@ class HealthRouteSpec extends AnyFlatSpec with Matchers {
   implicit val engineConfig: EngineConfig = new EngineConfig()
   implicit val ec: ExecutionContext = ExecutionContext.global
 
-  private def healthResponse(gameRepo: Option[GameRecordRepo]): (Status, Json) =
+  private def healthResponse(gameRepo: Either[String, GameRecordRepo]): (Status, Json) =
     Dispatcher.parallel[IO].use { dispatcher =>
       for {
         rm   <- RoomManager.create(new RoomRepo(xa), dispatcher, gameRepo)
@@ -38,7 +38,7 @@ class HealthRouteSpec extends AnyFlatSpec with Matchers {
     assume(available, "Postgres not reachable")
     repo.init.unsafeRunSync()
 
-    val (status, body) = healthResponse(Some(repo))
+    val (status, body) = healthResponse(Right(repo))
     status shouldBe Status.Ok
     field(body, "status").asString shouldBe Some("ok")
     field(body, "recording").asBoolean shouldBe Some(true)
@@ -49,10 +49,11 @@ class HealthRouteSpec extends AnyFlatSpec with Matchers {
   it should "report degraded with 503 when recording is disabled" in {
     assume(available, "Postgres not reachable")
 
-    val (status, body) = healthResponse(None)
+    val (status, body) = healthResponse(Left("init failed at boot: simulated"))
     status shouldBe Status.ServiceUnavailable
     field(body, "status").asString shouldBe Some("degraded")
     field(body, "recording").asBoolean shouldBe Some(false)
-    field(body, "recordingError").asString.getOrElse("") should include("disabled")
+    // The boot-failure cause must surface in the health body, not only in logs.
+    field(body, "recordingError").asString.getOrElse("") should include("simulated")
   }
 }


### PR DESCRIPTION
## What

Follow-up to #34 (7-day silent recording outage) for #30: the health endpoint now tells the truth about the flywheel's linchpin.

- `GET /api/health` → **200** `{status: ok, recording: true, gamesRecorded: N, recordingError: null, champion: ok}` only when the game-record repo is wired **and** a live DB round-trip succeeds.
- → **503** `{status: degraded, recording: false, recordingError: ...}` when recording is off or Postgres is unreachable *right now* — so a plain `curl`/uptime check catches the #34 failure mode instead of it hiding in boot logs.
- `GameRecordRepo.countGames` doubles as the liveness probe; `RoomManager.recordingHealth` exposes it.
- DEPLOY.md checks section updated.

## Tests

`sbt server/test`: 12/12 pass, including new `HealthRouteSpec` covering both the 200/ok and 503/degraded paths at the route level.

Part of #30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)